### PR TITLE
Follow CycloneDX 1.4 spec for SPDX license expressions for npm.

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -236,7 +236,9 @@ export function getLicenses(pkg, format = "xml") {
         }
         return licenseContent;
       })
-      .map((l) => (l.expression ? { expression: l } : { license: l }));
+      .map((l) =>
+        l.expression ? { expression: l.expression } : { license: l }
+      );
   }
   return undefined;
 }

--- a/utils.js
+++ b/utils.js
@@ -221,6 +221,8 @@ export function getLicenses(pkg, format = "xml") {
               licenseContent.name = "CUSTOM";
             }
             licenseContent.url = l;
+          } else if (l.includes(" ") || l.includes("(")) {
+            licenseContent.expression = l;
           } else {
             licenseContent.name = l;
           }
@@ -234,7 +236,7 @@ export function getLicenses(pkg, format = "xml") {
         }
         return licenseContent;
       })
-      .map((l) => ({ license: l }));
+      .map((l) => (l.expression ? { expression: l } : { license: l }));
   }
   return undefined;
 }

--- a/utils.test.js
+++ b/utils.test.js
@@ -1591,6 +1591,16 @@ test("get licenses", () => {
       }
     }
   ]);
+
+  let inputLicense = "(MIT or Apache-2.0)";
+  licenses = getLicenses({
+    license: inputLicense
+  });
+  expect(licenses).toEqual([
+    {
+      expression: inputLicense
+    }
+  ]);
 });
 
 test("parsePkgLock v1", async () => {


### PR DESCRIPTION
Support spdx expressions for CycloneDX 1.4 Spec