### PR TITLE
allow dockerfile scan on filesystem analysis

### DIFF
--- a/index.js
+++ b/index.js
@@ -4925,6 +4925,31 @@ export const createMultiXBom = async (pathList, options) => {
         listComponents(options, {}, bomData.bomJson.components, "maven", "xml")
       );
     }
+    bomData = await createContainerSpecLikeBom(path, options);
+    if (
+      bomData &&
+      bomData.bomJson &&
+      bomData.bomJson.components &&
+      bomData.bomJson.components.length
+    ) {
+      if (DEBUG_MODE) {
+        console.log(
+          `Found ${bomData.bomJson.components.length} docker dependencies at ${path}`
+        );
+      }
+      components = components.concat(bomData.bomJson.components);
+      dependencies = dependencies.concat(bomData.bomJson.dependencies);
+      if (
+        bomData.parentComponent &&
+        Object.keys(bomData.parentComponent).length
+      ) {
+        parentSubComponents.push(bomData.parentComponent);
+      }
+      componentsXmls = componentsXmls.concat(
+        // COPIED FROM SECTION ABOVE BUT NO IDEA OF PARAMETERS VALUES TO PUT
+        listComponents(options, {}, bomData.bomJson.components, "docker", "tar")
+      );
+    }
   } // for
   if (options.lastWorkingDir && options.lastWorkingDir !== "") {
     bomData = await createJarBom(options.lastWorkingDir, options);


### PR DESCRIPTION
When performing the filesystem analysis it should automatically detect the language supported. It appears that dockerfile scanning is not automatically performed whereas other langages are processed. Add the missing dockerfile analysis