### PR TITLE
Use node 21 for sae builds

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20.5
+          node-version: 21.x
       - name: Produce sae
         run: |
           npm ci

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 21.x
         registry-url: https://registry.npmjs.org/
     - name: Trim CI agent
       run: |
@@ -52,7 +52,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 21.x
         registry-url: https://registry.npmjs.org/
     - name: Trim CI agent
       run: |


### PR DESCRIPTION
Node 21.5.0 includes the new [simdjson](https://github.com/nodejs/node/commit/0dd53da722#diff-8b6c8a018ff01d0c75bac2da20d8422e260cd5fc538dd0a049ea9a4f283e9344) feature that improves json parsing performance by around 5%.

Might be unnecessary since caxa appears to be an archived project.

https://github.com/CycloneDX/cdxgen/issues/798