### PR TITLE
Added a postgen workaround to make bom compatible with dependency track

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -46,7 +46,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       run: |
         npm install
-        npx jsr publish
+        npx jsr publish --allow-dirty
       continue-on-error: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -246,7 +246,7 @@ const args = yargs(hideBin(process.argv))
   .option("make-dt-compatible", {
     type: "boolean",
     default: false,
-    description: "Just make the BOM compatible for dependency track.",
+    description: "Just make the BOM compatible with dependency track.",
     hidden: true
   })
   .completion("completion", "Generate bash/zsh completion")

--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -243,6 +243,12 @@ const args = yargs(hideBin(process.argv))
     default: false,
     description: "Include crypto libraries found under formulation."
   })
+  .option("make-dt-compatible", {
+    type: "boolean",
+    default: false,
+    description: "Just make the BOM compatible for dependency track.",
+    hidden: true
+  })
   .completion("completion", "Generate bash/zsh completion")
   .array("filter")
   .array("only")
@@ -429,7 +435,13 @@ const checkPermissions = (filePath) => {
     options.usagesSlicesFile = `${options.projectName}-usages.json`;
   }
   let bomNSData = (await createBom(filePath, options)) || {};
-  if (options.requiredOnly || options["filter"] || options["only"]) {
+  if (
+    options.requiredOnly ||
+    options["filter"] ||
+    options["only"] ||
+    options["make-dt-compatible"] ||
+    options.serverUrl
+  ) {
     bomNSData = postProcess(bomNSData, options);
   }
   if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cyclonedx/cdxgen",
-      "version": "10.2.4",
+      "version": "10.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",


### PR DESCRIPTION
New argument `--make-dt-compatible` to make the BOM compatible for dependency track

Fixes #897 
