### PR TITLE
Fix generating dependency trees info for dockerized NodeJS projects

### DIFF
--- a/index.js
+++ b/index.js
@@ -1850,12 +1850,6 @@ export async function createNodejsBom(path, options) {
           pkgList = pkgList.concat(dlist);
         }
       }
-      return buildBomNSData(options, pkgList, "npm", {
-        allImports: {},
-        src: path,
-        filename: "package.json",
-        parentComponent
-      });
     }
   }
   let allImports = {};


### PR DESCRIPTION
Solve issue [[NodeJs][Docker] Error getting Dependency Tree in NodeJS Docker images](https://github.com/CycloneDX/cdxgen/issues/926) by removing premature return when generating SBOM from dockerized NodeJS images. Because of this return the lock files are not being read and the dependency trees are staying empty.