### PR TITLE
feat(server): support passing `fetchLicense`

### DIFF
--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -52,6 +52,7 @@ Arguments can be passed either via the query string or as a JSON body. The follo
 | only             | Include components only containing this word in purl. Useful to generate BOM with first party components alone. Multiple values allowed. [array] |
 | autoCompositions | Automatically set compositions when the BOM was filtered. [boolean] [default: true]                                                              |
 | gitBranch        | Git branch used when cloning the repository. If not specified will use the default branch assigned to the repository.                            |
+| fetchLicense     | Automatically query public registries such as maven, npm, or nuget to resolve the package licenses. This is a time-consuming operation and is disabled by default.              |
 
 ## Ways to use server mode
 

--- a/index.js
+++ b/index.js
@@ -134,8 +134,8 @@ import {
   parseSwiftResolved,
   parseYarnLock,
   readZipEntry,
+  shouldFetchLicense,
   splitOutputByGradleProjects,
-  shouldFetchLicense
 } from "./utils.js";
 let url = import.meta.url;
 if (!url.startsWith("file://")) {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ import {
   CARGO_CMD,
   CLJ_CMD,
   DEBUG_MODE,
-  FETCH_LICENSE,
   LEIN_CMD,
   MAX_BUFFER,
   PREFER_MAVEN_DEPS_TREE,
@@ -136,6 +135,7 @@ import {
   parseYarnLock,
   readZipEntry,
   splitOutputByGradleProjects,
+  shouldFetchLicense
 } from "./utils.js";
 let url = import.meta.url;
 if (!url.startsWith("file://")) {
@@ -3100,7 +3100,7 @@ export async function createPythonBom(path, options) {
   if (tempDir?.startsWith(tmpdir()) && rmSync) {
     rmSync(tempDir, { recursive: true, force: true });
   }
-  if (FETCH_LICENSE) {
+  if (shouldFetchLicense()) {
     pkgList = await getPyMetadata(pkgList, false);
   }
   return buildBomNSData(options, pkgList, "pypi", {
@@ -4280,7 +4280,7 @@ export async function createSwiftBom(path, options) {
       }
     }
   }
-  if (FETCH_LICENSE) {
+  if (shouldFetchLicense()) {
     pkgList = await getSwiftPackageMetadata(pkgList);
   }
   return buildBomNSData(options, pkgList, "swift", {
@@ -5209,7 +5209,7 @@ export async function createCsharpBom(path, options) {
       dependsOn: Array.from(parentDependsOn),
     });
   }
-  if (FETCH_LICENSE) {
+  if (shouldFetchLicense()) {
     const retMap = await getNugetMetadata(pkgList, dependencies);
     if (retMap.dependencies?.length) {
       dependencies = mergeDependencies(

--- a/server.js
+++ b/server.js
@@ -92,6 +92,7 @@ const parseQueryString = (q, body, options = {}) => {
     "includeFormulation",
     "includeCrypto",
     "standard",
+    "fetchLicense"
   ];
 
   for (const param of queryParams) {
@@ -114,6 +115,9 @@ const parseQueryString = (q, body, options = {}) => {
   }
   if (options.profile) {
     applyProfileOptions(options);
+  }
+  if (options.fetchLicense) {
+    process.env.FETCH_LICENSE = options.fetchLicense
   }
   return options;
 };

--- a/server.js
+++ b/server.js
@@ -92,7 +92,7 @@ const parseQueryString = (q, body, options = {}) => {
     "includeFormulation",
     "includeCrypto",
     "standard",
-    "fetchLicense"
+    "fetchLicense",
   ];
 
   for (const param of queryParams) {
@@ -117,7 +117,7 @@ const parseQueryString = (q, body, options = {}) => {
     applyProfileOptions(options);
   }
   if (options.fetchLicense) {
-    process.env.FETCH_LICENSE = options.fetchLicense
+    process.env.FETCH_LICENSE = options.fetchLicense;
   }
   return options;
 };

--- a/utils.js
+++ b/utils.js
@@ -129,7 +129,10 @@ export const PREFER_MAVEN_DEPS_TREE =
 
 // Whether license information should be fetched
 export function shouldFetchLicense() {
-    return process.env.FETCH_LICENSE && ["true", "1"].includes(process.env.FETCH_LICENSE);
+  return (
+    process.env.FETCH_LICENSE &&
+    ["true", "1"].includes(process.env.FETCH_LICENSE)
+  );
 }
 
 // Whether search.maven.org will be used to identify jars without maven metadata; default, if unset shall be 'true'
@@ -791,7 +794,6 @@ export async function getNpmMetadata(pkgList) {
         p.homepage = { url: body.homepage };
       }
       cdepList.push(p);
-      
     } catch (err) {
       cdepList.push(p);
       if (DEBUG_MODE) {


### PR DESCRIPTION
Add support for fetching license information dynamically via CDXGEN Server as an API argument.  

The allows the calling workflow to determine if they want license enrichment, or not.

Also added some additional logging to some of the metadata lookup functions. (lots more is desirable still)


---
Also, while performing this update, I noticed that `getMvnMetadata()` looked a bit unusual
https://github.com/CycloneDX/cdxgen/blob/aa6552bba2d7a0e2189d3254c587b43f40c38062/utils.js#L3179
Unclear why the `FETCH_LICENSE` guard is only applied to a log statement and not any of the metadata logic