### PR TITLE
Filter yarn deps to direct deps for main package

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2873,9 +2873,15 @@ export async function createNodejsBom(path, options) {
       }
       const rdeplist = [];
       if (parsedList.dependenciesList && parsedList.dependenciesList) {
+        // copyright (c) 2025 Atlassian US, Inc.
+        // First read package.json to get direct dependencies
+        const pkgData = JSON.parse(readFileSync(packageJsonF, "utf8"));
+        const directDeps = {
+          ...(pkgData.dependencies || {}),
+          ...(pkgData.devDependencies || {}),
+        };
         // Inject parent component to the dependency tree to make it complete
-        // In case of yarn, yarn list command lists every root package as a direct dependency
-        // The same logic is matched with this for loop although this is incorrect since even dev dependencies would get included here
+        // Add only direct dependencies to the dependency tree of the parent component
         for (const dobj of parsedList.dependenciesList) {
           rdeplist.push(dobj.ref);
         }
@@ -2892,7 +2898,10 @@ export async function createNodejsBom(path, options) {
           ).toString();
           parsedList.dependenciesList.push({
             ref: decodeURIComponent(ppurl),
-            dependsOn: [...new Set(rdeplist)].sort(),
+            dependsOn: rdeplist.filter(ref => {
+              const pkgName = ref.split('/')[1].split('@')[0];
+              return directDeps.hasOwnProperty(pkgName);
+            }).sort(),
           });
         }
         dependencies = mergeDependencies(


### PR DESCRIPTION
This is related to https://github.com/CycloneDX/cdxgen/issues/1085

Context: 
- When creating the dependency list for the main package in yarn.lock parsing, we are currently passing all the dependencies(direct and transitive) for the parent component(main package)
- Systems parsing the cycloneDX SBOM file to make sense of direct and transitive dependencies assume that all of these are direct dependencies(which is the case for other tech stacks)
- This was earlier brought up in issue [1085](https://github.com/CycloneDX/cdxgen/issues/1085) where it was suggested to open a pull request, but wasn't done.
- The current logic is based on the `yarn list --depth=0` which is also incorrect and has been acknowledged [here](https://github.com/yarnpkg/yarn/issues/3569)

Changes:
- I'm getting the direct dependencies list from the `package.json` file
- Then filtering on the `dependenciesList` and only adding direct ones to the main package

Signed-off-by: Sahil Seth <sseth@atlassian.com>