### PR TITLE
MXFP4 quants

### DIFF
--- a/contrib/fine-tuning/fine-tune-mlx.sh
+++ b/contrib/fine-tuning/fine-tune-mlx.sh
@@ -45,6 +45,7 @@ FUSED_MODEL=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}
 QUANT_MODEL_8BIT=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-8bit
 QUANT_MODEL_6BIT=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-6bit
 QUANT_MODEL_4BIT=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-4bit
+QUANT_MODEL_MXFP4=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-MXFP4
 DWQ_QUANT_MODEL_4BIT=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-4bit-DWQ
 
 ### mlx-lm needs train.jsonl and valid.jsonl
@@ -108,6 +109,11 @@ rm -rf ${QUANT_MODEL_6BIT}
 mlx_lm.convert --hf-path ${FUSED_MODEL} --mlx-path ${QUANT_MODEL_6BIT} -q --q-bits 6 --dtype bfloat16
 echo "Test ${QUANT_MODEL_6BIT} with the prompt 'Tell me about cdxgen'. Must yield a better response."
 mlx_lm.generate --model ./${QUANT_MODEL_6BIT} --prompt "Tell me about cdxgen" --temp ${TEMP} --max-tokens ${MAX_TOKENS}
+
+rm -rf ${QUANT_MODEL_MXFP4}
+mlx_lm.convert --hf-path ${FUSED_MODEL} --mlx-path ${QUANT_MODEL_MXFP4} -q --q-bits 4 --q-group-size 32 --q-mode mxfp4 --dtype bfloat16
+echo "Test ${QUANT_MODEL_MXFP4} with the prompt 'Tell me about cdxgen'. Must yield a better response."
+mlx_lm.generate --model ./${QUANT_MODEL_MXFP4} --prompt "Tell me about cdxgen" --temp ${TEMP} --max-tokens ${MAX_TOKENS}
 
 # 4-bit for a small model has very poor performance
 if [ "$TOOL_BASE_MODEL" != "cdx1-mini" ] && [ "$TOOL_BASE_MODEL" != "cdx1-nano" ]; then

--- a/contrib/fine-tuning/upload-hf.sh
+++ b/contrib/fine-tuning/upload-hf.sh
@@ -10,6 +10,7 @@ FUSED_MODEL=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}
 QUANT_MODEL_8BIT=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-8bit
 QUANT_MODEL_6BIT=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-6bit
 QUANT_MODEL_4BIT=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-4bit
+QUANT_MODEL_MXFP4=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-MXFP4
 DWQ_QUANT_MODEL_4BIT=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-4bit-DWQ
 
 hf auth whoami
@@ -20,12 +21,13 @@ hf upload --quiet --repo-type dataset CycloneDX/cdx-docs ./guides guides
 hf upload --quiet --repo-type dataset CycloneDX/cdx-docs ./semantics semantics
 
 echo "Uploading models. Please wait ..."
-hf upload --quiet --exclude "**/README.md" --repo-type model ${QUANT_MODEL_8BIT} ./${QUANT_MODEL_8BIT} .
-hf upload --quiet --exclude "**/README.md" --repo-type model ${QUANT_MODEL_6BIT} ./${QUANT_MODEL_6BIT} .
+hf upload --quiet --exclude "**/README.md" --repo-type model ${QUANT_MODEL_8BIT} ./${QUANT_MODEL_8BIT} --delete "*.safetensors" .
+hf upload --quiet --exclude "**/README.md" --repo-type model ${QUANT_MODEL_MXFP4} ./${QUANT_MODEL_MXFP4} --delete "*.safetensors" .
+hf upload --quiet --exclude "**/README.md" --repo-type model ${QUANT_MODEL_6BIT} ./${QUANT_MODEL_6BIT} --delete "*.safetensors" .
 if [ "$TOOL_BASE_MODEL" != "cdx1-mini" ] && [ "$TOOL_BASE_MODEL" != "cdx1-nano" ]; then
-  hf upload --quiet --exclude "**/README.md" --repo-type model ${QUANT_MODEL_4BIT} ./${QUANT_MODEL_4BIT} .
+  hf upload --quiet --exclude "**/README.md" --repo-type model ${QUANT_MODEL_4BIT} ./${QUANT_MODEL_4BIT} --delete "*.safetensors" .
 fi
 #if [ "$TOOL_BASE_MODEL" != "cdx1-mini" ]; then
 #  hf upload --quiet --exclude "**/README.md" --repo-type model ${DWQ_QUANT_MODEL_4BIT} ./${DWQ_QUANT_MODEL_4BIT} .
 #fi
-hf upload --quiet --exclude "**/README.md" --repo-type model ${FUSED_MODEL} ./${FUSED_MODEL} .
+hf upload --quiet --exclude "**/README.md" --repo-type model ${FUSED_MODEL} ./${FUSED_MODEL} --delete "*.safetensors" .


### PR DESCRIPTION
If OpenAI can do it, so can we.

cdx1 models are now available in MXFP4 quants in both [MLX](https://huggingface.co/CycloneDX/cdx1-pro-mlx-MXFP4) and [GGUF](https://huggingface.co/CycloneDX/cdx1-pro-30B-MXFP4-GGUF) formats.

The [quantization](https://huggingface.co/CycloneDX/cdx1-pro-mlx-MXFP4/blob/main/config.json#L28) attribute in the config file should give an idea about its complexity compared to legacy [quants](https://huggingface.co/CycloneDX/cdx1-pro-mlx-8bit/blob/main/config.json#L28).

## Limitations

**cdx1** uses `unsloth/Qwen2.5-Coder-14B-Instruct` as the base image and doesn't benefit from this hybrid quant. We lack compute for DWQ quants, so we are stuck a bit.

## Benchmarks

TBD

## Screenshots (cdx1-pro)

<img width="1816" height="1192" alt="Screenshot 2025-08-21 at 01 26 16" src="https://github.com/user-attachments/assets/cca056a4-ed17-44c6-8311-d2537b23d0a0" />
<img width="1816" height="1025" alt="Screenshot 2025-08-21 at 01 27 46" src="https://github.com/user-attachments/assets/8d38b8b1-cb67-473e-9c71-80fca36d0e35" />

## GLM-4.5 analysis of the configurations

gpt-oss-20b - https://huggingface.co/openai/gpt-oss-20b/raw/main/config.json
cdx1-pro-mlx-MXFP4 - https://huggingface.co/CycloneDX/cdx1-pro-mlx-MXFP4/raw/main/config.json

----------------

# Analysis of Two LLM Model Configurations

I'll analyze the differences between these two models and provide insights on their efficiency for different purposes.

## Model 1: GptOssForCausalLM

### Architecture & Size
- **Model Type**: GPT-based architecture with MoE (Mixture of Experts)
- **Hidden Size**: 2880
- **Layers**: 24 hidden layers
- **Attention Heads**: 64 heads with 8 key-value heads (indicating Grouped-Query Attention)
- **Experts**: 32 local experts, using 4 experts per token
- **Vocabulary**: 201,088 tokens

### Attention Mechanism
- Uses alternating sliding and full attention layers
- Sliding window of 128 tokens
- Attention bias enabled
- No attention dropout

### Context Handling
- Max position embeddings: 131,072
- Uses RoPE (Rotary Position Embedding) with "yarn" scaling
- Initial context length: 4,096

### Quantization
- MXFP4 quantization method
- Certain modules excluded from quantization (self-attention, router, embeddings, output head)

## Model 2: Qwen3MoeForCausalLM

### Architecture & Size
- **Model Type**: Qwen3-based architecture with MoE
- **Hidden Size**: 2048
- **Layers**: 48 hidden layers (twice as many as Model 1)
- **Attention Heads**: 32 heads with 4 key-value heads
- **Experts**: 128 experts (4x more than Model 1), using 8 experts per token
- **Vocabulary**: 151,936 tokens

### Attention Mechanism
- No sliding window attention
- QK normalization enabled
- Attention bias disabled
- No attention dropout

### Context Handling
- Max position embeddings: 262,144 (2x larger than Model 1)
- Uses RoPE with higher theta value (10,000,000 vs 150,000)
- No RoPE scaling

### Quantization
- 4-bit quantization with group size 32
- Special handling for gate layers (8-bit with group size 64)
- Uses bfloat16 precision
- Includes "unsloth_fixed" optimization

## Key Differences

1. **Model Structure**: Model 1 has fewer layers (24) but larger hidden size (2880), while Model 2 has more layers (48) but smaller hidden size (2048).

2. **Attention Mechanism**: Model 1 uses sliding attention which can be more efficient for long sequences, while Model 2 uses QK normalization which may improve stability.

3. **MoE Configuration**: Model 2 has significantly more experts (128 vs 32) and uses more experts per token (8 vs 4).

4. **Context Length**: Model 2 supports a larger context length (262,144 vs 131,072).

5. **Quantization**: Different approaches - Model 1 uses MXFP4 with exclusions, while Model 2 uses 4-bit with special gate handling.

## Efficiency Analysis

### Training Efficiency
**Model 2 (Qwen3MoeForCausalLM)** is likely more efficient for training because:
- Smaller hidden size reduces memory footprint per layer
- The "unsloth_fixed" parameter suggests optimizations from the Unsloth library
- More experts allow for better model capacity with distributed computation
- Explicit bfloat16 precision provides good balance between precision and memory

### Inference Efficiency
**Model 1 (GptOssForCausalLM)** would likely be more efficient for inference because:
- Fewer layers reduce computation time
- Sliding window attention significantly reduces computation for longer sequences
- Fewer experts per token (4 vs 8) means less computation during the forward pass
- Despite having a larger hidden size, the overall architecture is simpler

### Fine-tuning Efficiency
**Model 1 (GptOssForCausalLM)** would likely be more efficient for fine-tuning because:
- Fewer parameters make it faster to train and require less memory
- The sliding attention mechanism is beneficial for tasks with long sequences
- MXFP4 quantization may provide a good balance of precision and efficiency

However, if the fine-tuning task requires significant adaptation, **Model 2** might be preferable due to its larger number of experts, which could allow for more specialized adaptation.

## Conclusion

- **For Training**: Model 2 (Qwen3MoeForCausalLM) is likely more efficient due to optimizations and better parameter distribution.
- **For Inference**: Model 1 (GptOssForCausalLM) would be more efficient, especially for longer sequences, due to its sliding attention and simpler architecture.
- **For Fine-tuning**: Model 1 is generally more efficient, but Model 2 could be better for tasks requiring substantial adaptation.

The choice ultimately depends on your specific use case, available computational resources, and the nature of your tasks.