### PR TITLE
fix(nuget): populate package metadata from cache on repeated server requests

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -16731,58 +16731,59 @@ export async function getNugetMetadata(pkgList, dependencies = undefined) {
         }
         if (body) {
           metadata_cache[cacheKey] = body;
-          // Set the latest version in case it is missing
-          if (!p.version && body.catalogEntry.version) {
-            p.version = body.catalogEntry.version;
-          }
-          p.description = body.catalogEntry.description;
-          if (body.catalogEntry.authors) {
-            p.author = body.catalogEntry.authors.trim();
-          }
-          if (
-            body.catalogEntry.licenseExpression &&
-            body.catalogEntry.licenseExpression !== ""
-          ) {
-            p.license = findLicenseId(body.catalogEntry.licenseExpression);
-          } else if (body.catalogEntry.licenseUrl) {
-            p.license = findLicenseId(body.catalogEntry.licenseUrl);
-            if (
-              typeof p.license === "string" &&
-              p.license.includes("://github.com/")
-            ) {
-              p.license =
-                (await getRepoLicense(p.license, undefined)) || p.license;
-            }
-          }
-          // Capture the tags
-          if (
-            body.catalogEntry?.tags?.length &&
-            Array.isArray(body.catalogEntry.tags)
-          ) {
-            p.tags = body.catalogEntry.tags.map((t) =>
-              t.toLowerCase().replaceAll(" ", "-"),
-            );
-          }
-          if (body.catalogEntry.projectUrl) {
-            p.repository = { url: body.catalogEntry.projectUrl };
-            p.homepage = {
-              url: `https://www.nuget.org/packages/${p.name}/${p.version}/`,
-            };
-            if (
-              (!p.license || typeof p.license === "string") &&
-              typeof p.repository.url === "string" &&
-              p.repository.url.includes("://github.com/")
-            ) {
-              // license couldn't be properly identified and is still a url,
-              // therefore trying to resolve license via repository
-              p.license =
-                (await getRepoLicense(p.repository.url, undefined)) ||
-                p.license;
-            }
-          }
-          cdepList.push(p);
         }
       }
+      if (body) {
+        // Set the latest version in case it is missing
+        if (!p.version && body.catalogEntry.version) {
+          p.version = body.catalogEntry.version;
+        }
+        p.description = body.catalogEntry.description;
+        if (body.catalogEntry.authors) {
+          p.author = body.catalogEntry.authors.trim();
+        }
+        if (
+          body.catalogEntry.licenseExpression &&
+          body.catalogEntry.licenseExpression !== ""
+        ) {
+          p.license = findLicenseId(body.catalogEntry.licenseExpression);
+        } else if (body.catalogEntry.licenseUrl) {
+          p.license = findLicenseId(body.catalogEntry.licenseUrl);
+          if (
+            typeof p.license === "string" &&
+            p.license.includes("://github.com/")
+          ) {
+            p.license =
+              (await getRepoLicense(p.license, undefined)) || p.license;
+          }
+        }
+        // Capture the tags
+        if (
+          body.catalogEntry?.tags?.length &&
+          Array.isArray(body.catalogEntry.tags)
+        ) {
+          p.tags = body.catalogEntry.tags.map((t) =>
+            t.toLowerCase().replaceAll(" ", "-"),
+          );
+        }
+        if (body.catalogEntry.projectUrl) {
+          p.repository = { url: body.catalogEntry.projectUrl };
+          p.homepage = {
+            url: `https://www.nuget.org/packages/${p.name}/${p.version}/`,
+          };
+          if (
+            (!p.license || typeof p.license === "string") &&
+            typeof p.repository.url === "string" &&
+            p.repository.url.includes("://github.com/")
+          ) {
+            // license couldn't be properly identified and is still a url,
+            // therefore trying to resolve license via repository
+            p.license =
+              (await getRepoLicense(p.repository.url, undefined)) || p.license;
+          }
+        }
+      }
+      cdepList.push(p);
     } catch (err) {
       if (cacheKey) {
         metadata_cache[cacheKey] = { error: err.code };


### PR DESCRIPTION
### Problem
When cdxgen runs in server mode (--server), repeated SBOM requests for the
same .NET project return packages without licenses, descriptions, and other
metadata. Only the first request after startup fetches complete data.

### Root Cause
In `getNugetMetadata`, the block that populates package fields
(license, description, author, tags, repository) was nested inside
`if (!body)` — the branch that only executes when the cache is empty.

On subsequent requests, `body` is retrieved from `metadata_cache` but
the fields are never applied to the package object, and `cdepList.push(p)`
is never called from the cache-hit path.

### Fix
Extract the field-population logic and `cdepList.push(p)` outside of
`if (!body)`, so they execute regardless of whether `body` came from
cache or a fresh NuGet API call. This matches the pattern already used
in `getNpmMetadata`.

### Reproduction
1. Start cdxgen in server mode
2. Send SBOM request for a .NET project — response includes licenses (~1761kb)
3. Send same request again — response missing licenses (~1477kb)