### PR TITLE
Add missing licenses: JSR-000107

### DIFF
--- a/data/known-licenses.json
+++ b/data/known-licenses.json
@@ -1,7 +1,13 @@
 [
   {
     "packageNamespace": "*",
-    "knownLicenses": [{ "license": "MIT", "urlIncludes": "mit-license" }]
+    "knownLicenses": [
+      { "license": "MIT", "urlIncludes": "mit-license" },
+      {
+        "licenseName": "JSR-000107 JCACHE 2.9 Public Review - Updated Specification License",
+        "urlIncludes": "raw.github.com/jsr107/jsr107spec/master/LICENSE.txt"
+      }
+    ]
   },
   {
     "packageNamespace": "pkg:golang/",

--- a/data/lic-mapping.json
+++ b/data/lic-mapping.json
@@ -1,5 +1,12 @@
 [
   {
+    "exp": "https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt",
+    "names": [
+      "JSR-000107 JCACHE 2.9 Public Review - Updated Specification\n                License\n            ",
+      "JSR-000107 JCACHE 2.9 Public Review - Updated Specification License"
+    ]
+  },
+  {
     "exp": "Apache-2.0",
     "names": [
       "Apache2",


### PR DESCRIPTION
Hi! We've came across a problem where CDXGEN will not fetch unknow licenses for well known libs like cache-api.
Please accept patch to be able to fetch it correctly.