### PR TITLE
fix: correct docs-support link and update outdated version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ cdxgen is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff
 Minimal example:
 
 ```ts
-import { createBom, submitBom } from "npm:@cyclonedx/cdxgen@^9.0.1";
+import { createBom, submitBom } from "npm:@cyclonedx/cdxgen@^12.0.0";
 ```
 
 See the [Deno Readme](./contrib/deno/README.md) for detailed instructions.
@@ -634,7 +634,7 @@ Copy the below block to your markdown files to show your ❤️ for cdxgen.
 [docs-permissions]: https://cdxgen.github.io/cdxgen/#/PERMISSIONS
 [docs-project-types]: https://cdxgen.github.io/cdxgen/#/PROJECT_TYPES
 [docs-server]: https://cdxgen.github.io/cdxgen/#/SERVER
-[docs-support]: https://cdxgen.github.io/cdxgen/#/PROJECT_TYPES
+[docs-support]: https://cdxgen.github.io/cdxgen/#/SUPPORT
 
 <!-- web links-->
 


### PR DESCRIPTION
## Summary

- **Fix broken docs-support link**: The `[docs-support]` reference link was pointing to `#/PROJECT_TYPES` instead of `#/SUPPORT`, causing the "Support (Enterprise & Community)" link in the Documentation section to navigate to the wrong page.
- **Update outdated version in deno import example**: The "Integration as library" section had an outdated deno import example using `@^9.0.1`. Updated it to `@^12.0.0` to match the current major version.

## Test plan

- [ ] Verify the [Support (Enterprise & Community)] link in the rendered README navigates to the correct SUPPORT documentation page
- [ ] Verify the deno import example in the "Integration as library" section shows the current version range

🤖 Generated with [Claude Code](https://claude.com/claude-code)