### PR TITLE
[gradle] Fix incorrect SBOM with unresolved dependencies

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -7224,9 +7224,9 @@ export async function parseGradleDep(
       rline = rline.replace("\r", "");
       if (
         rline.endsWith("(n)") ||
-        (rline.startsWith("+--- ") || rline.startsWith("\\--- ")) &&
-        rline.includes("{strictly") &&
-        rline.includes("(c)")
+        ((rline.startsWith("+--- ") || rline.startsWith("\\--- ")) &&
+          rline.includes("{strictly") &&
+          rline.includes("(c)"))
       ) {
         continue;
       }

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -7223,6 +7223,7 @@ export async function parseGradleDep(
       }
       rline = rline.replace("\r", "");
       if (
+        rline.endsWith("(n)") ||
         (rline.startsWith("+--- ") || rline.startsWith("\\--- ")) &&
         rline.includes("{strictly") &&
         rline.includes("(c)")

--- a/lib/helpers/utils.poku.js
+++ b/lib/helpers/utils.poku.js
@@ -1103,7 +1103,7 @@ it("parse gradle dependencies", async () => {
     properties: [
       {
         name: "GradleProfileName",
-        value: "androidTestImplementation",
+        value: "debugAndroidTestCompileClasspath",
       },
     ],
     "bom-ref": "pkg:maven/com.android.support.test/runner@1.0.2?type=jar",


### PR DESCRIPTION
Some dependencies in Grade are not resolved for certain tasks -- eg when using the 'platform' construct with 'latest.release'. cdxgen would then incorrectly include these dependencies AS WELL AS the later resolved version(s) of these dependencies.

This fix ignores all unresolved dependencies, so the generated SBOM will only contain the actually correctly resolved dependencies of the project.