### PR TITLE
[go] Fix crash on empty go.mod file

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -5469,7 +5469,10 @@ export async function createGoBom(path, options) {
         pkgList = pkgList.concat(retMap.pkgList);
       }
       // Retain the parent component hierarchy, prioritizing the shallowest module
-      if (Object.keys(retMap.parentComponent).length) {
+      if (
+        retMap?.parentComponent &&
+        Object.keys(retMap.parentComponent).length
+      ) {
         if (!rootParentComponent) {
           // First (shallowest) module becomes the root
           rootParentComponent = retMap.parentComponent;


### PR DESCRIPTION
When encountering an empty go.mod file, we returned an empty object for its contents. Some of the code didn't correctly check for this and crashed the execution.