### PR TITLE
[conan] Fixed incorrect PURLs

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -14478,14 +14478,13 @@ function createConanPurlString(name, version, user, channel, rrev, prev) {
 
   const qualifiers = {};
 
-  if (user) qualifiers["user"] = user;
   if (channel) qualifiers["channel"] = channel;
   if (rrev) qualifiers["rrev"] = rrev;
   if (prev) qualifiers["prev"] = prev;
 
   return new PackageURL(
     "conan",
-    "",
+    user,
     name,
     version,
     Object.keys(qualifiers).length ? qualifiers : null,
@@ -14528,7 +14527,7 @@ export function mapConanPkgRefToPurlStringAndNameAndVersion(conanPkgRef) {
   // See also https://docs.conan.io/1/cheatsheet.html#package-terminology
 
   // The components 'package_id' and 'package_revision' do not appear in any files processed by cdxgen.
-  // The components 'user' and 'channel' are not mandatory.
+  // The components 'user' and 'channel' are not mandatory, however if present, they MUST both appear!
   // 'name/version' is a valid Conan package reference, so is 'name/version@user/channel' or 'name/version@user/channel#recipe_revision'.
   // pURL for Conan does not recognize 'package_id'.
 
@@ -14644,7 +14643,7 @@ export function mapConanPkgRefToPurlStringAndNameAndVersion(conanPkgRef) {
     info.package_revision,
   );
 
-  return [purl, info.name, info.version];
+  return [purl, info.name, info.version, info.user];
 }
 
 /**

--- a/lib/helpers/utils.poku.js
+++ b/lib/helpers/utils.poku.js
@@ -3698,7 +3698,7 @@ it("conan package reference mapper to pURL", () => {
       mapConanPkgRefToPurlStringAndNameAndVersion(inputPkgRef);
     assert.deepStrictEqual(purl, expectedPurl);
 
-    const expectedPurlPrefix = `pkg:conan/${user ? user + '/' : ''}${name}@${version}`;
+    const expectedPurlPrefix = `pkg:conan/${user ? user : ""}${user ? "/" : ""}${name}@${version}`;
     assert.deepStrictEqual(
       purl.substring(0, expectedPurlPrefix.length),
       expectedPurlPrefix,

--- a/lib/helpers/utils.poku.js
+++ b/lib/helpers/utils.poku.js
@@ -3469,9 +3469,9 @@ it("parse conan data", () => {
   assert.deepStrictEqual(dep_list.length, 43);
   assert.deepStrictEqual(dep_list[0], {
     "bom-ref":
-      "pkg:conan/7-Zip@19.00?channel=stable&rrev=bb67aa9bc0da3feddc68ca9f334f4c8b&user=iw",
+      "pkg:conan/iw/7-Zip@19.00?channel=stable&rrev=bb67aa9bc0da3feddc68ca9f334f4c8b",
     name: "7-Zip",
-    purl: "pkg:conan/7-Zip@19.00?channel=stable&rrev=bb67aa9bc0da3feddc68ca9f334f4c8b&user=iw",
+    purl: "pkg:conan/iw/7-Zip@19.00?channel=stable&rrev=bb67aa9bc0da3feddc68ca9f334f4c8b",
     scope: "required",
     version: "19.00",
   });
@@ -3694,11 +3694,11 @@ it("parse collider lock data sanitizes origin metadata and tracks invalid wrap h
 
 it("conan package reference mapper to pURL", () => {
   const checkParseResult = (inputPkgRef, expectedPurl) => {
-    const [purl, name, version] =
+    const [purl, name, version, user] =
       mapConanPkgRefToPurlStringAndNameAndVersion(inputPkgRef);
     assert.deepStrictEqual(purl, expectedPurl);
 
-    const expectedPurlPrefix = `pkg:conan/${name}@${version}`;
+    const expectedPurlPrefix = `pkg:conan/${user ? user + '/' : ''}${name}@${version}`;
     assert.deepStrictEqual(
       purl.substring(0, expectedPurlPrefix.length),
       expectedPurlPrefix,
@@ -3716,21 +3716,20 @@ it("conan package reference mapper to pURL", () => {
 
   checkParseResult(
     "testpkg/1.2.3@someuser/somechannel",
-    "pkg:conan/testpkg@1.2.3?channel=somechannel&user=someuser",
+    "pkg:conan/someuser/testpkg@1.2.3?channel=somechannel",
   );
 
   checkParseResult(
     "testpkg/1.2.3@someuser/somechannel#recipe_revision",
-    "pkg:conan/testpkg@1.2.3?channel=somechannel&rrev=recipe_revision&user=someuser",
+    "pkg:conan/someuser/testpkg@1.2.3?channel=somechannel&rrev=recipe_revision",
   );
 
   checkParseResult(
     "testpkg/1.2.3@someuser/somechannel#recipe_revision:package_id#package_revision",
-    "pkg:conan/testpkg@1.2.3" +
+    "pkg:conan/someuser/testpkg@1.2.3" +
       "?channel=somechannel" +
       "&prev=package_revision" +
-      "&rrev=recipe_revision" +
-      "&user=someuser",
+      "&rrev=recipe_revision",
   );
 
   const expectParseError = (pkgRef) => {
@@ -3776,29 +3775,29 @@ it("parse conan data where packages use custom user/channel", () => {
     name: "libcurl",
     version: "8.1.2",
     "bom-ref":
-      "pkg:conan/libcurl@8.1.2?channel=stable&rrev=25215c550633ef0224152bc2c0556698&user=internal",
-    purl: "pkg:conan/libcurl@8.1.2?channel=stable&rrev=25215c550633ef0224152bc2c0556698&user=internal",
+      "pkg:conan/internal/libcurl@8.1.2?channel=stable&rrev=25215c550633ef0224152bc2c0556698",
+    purl: "pkg:conan/internal/libcurl@8.1.2?channel=stable&rrev=25215c550633ef0224152bc2c0556698",
   });
   assert.deepStrictEqual(conanLockData.pkgList[1], {
     name: "openssl",
     version: "3.1.0",
     "bom-ref":
-      "pkg:conan/openssl@3.1.0?channel=stable&rrev=c9c6ab43aa40bafacf8b37c5948cdb1f&user=internal",
-    purl: "pkg:conan/openssl@3.1.0?channel=stable&rrev=c9c6ab43aa40bafacf8b37c5948cdb1f&user=internal",
+      "pkg:conan/internal/openssl@3.1.0?channel=stable&rrev=c9c6ab43aa40bafacf8b37c5948cdb1f",
+    purl: "pkg:conan/internal/openssl@3.1.0?channel=stable&rrev=c9c6ab43aa40bafacf8b37c5948cdb1f",
   });
   assert.deepStrictEqual(conanLockData.pkgList[2], {
     name: "zlib",
     version: "1.2.13",
     "bom-ref":
-      "pkg:conan/zlib@1.2.13?channel=stable&rrev=aee6a56ff7927dc7261c55eb2db4fc5b&user=internal",
-    purl: "pkg:conan/zlib@1.2.13?channel=stable&rrev=aee6a56ff7927dc7261c55eb2db4fc5b&user=internal",
+      "pkg:conan/internal/zlib@1.2.13?channel=stable&rrev=aee6a56ff7927dc7261c55eb2db4fc5b",
+    purl: "pkg:conan/internal/zlib@1.2.13?channel=stable&rrev=aee6a56ff7927dc7261c55eb2db4fc5b",
   });
   assert.deepStrictEqual(conanLockData.pkgList[3], {
     name: "fmt",
     version: "10.0.0",
-    purl: "pkg:conan/fmt@10.0.0?channel=stable&rrev=79e7cc169695bc058fb606f20df6bb10&user=internal",
+    purl: "pkg:conan/internal/fmt@10.0.0?channel=stable&rrev=79e7cc169695bc058fb606f20df6bb10",
     "bom-ref":
-      "pkg:conan/fmt@10.0.0?channel=stable&rrev=79e7cc169695bc058fb606f20df6bb10&user=internal",
+      "pkg:conan/internal/fmt@10.0.0?channel=stable&rrev=79e7cc169695bc058fb606f20df6bb10",
   });
 
   const dep_list = parseConanData(
@@ -3810,15 +3809,15 @@ it("parse conan data where packages use custom user/channel", () => {
   assert.deepStrictEqual(dep_list[0], {
     name: "libcurl",
     version: "8.1.2",
-    "bom-ref": "pkg:conan/libcurl@8.1.2?channel=stable&user=internal",
-    purl: "pkg:conan/libcurl@8.1.2?channel=stable&user=internal",
+    "bom-ref": "pkg:conan/internal/libcurl@8.1.2?channel=stable",
+    purl: "pkg:conan/internal/libcurl@8.1.2?channel=stable",
     scope: "required",
   });
   assert.deepStrictEqual(dep_list[1], {
     name: "fmt",
     version: "10.0.0",
-    purl: "pkg:conan/fmt@10.0.0?channel=stable&user=internal",
-    "bom-ref": "pkg:conan/fmt@10.0.0?channel=stable&user=internal",
+    purl: "pkg:conan/internal/fmt@10.0.0?channel=stable",
+    "bom-ref": "pkg:conan/internal/fmt@10.0.0?channel=stable",
     scope: "optional",
   });
 });


### PR DESCRIPTION
Conan PURLs were not correct: conan requires a "namespace" component when a "channel" qualifier is present.

This issue was found when trying to upgrade the packageurl-js package.

This PR fixes this issue by using the 'user' variable in the conan definition as the namespace. Because the user is now already in the PURL, removed the explicit parameter 'user'.