### PR TITLE
[java] Fixed incorrect PURLs

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -371,7 +371,7 @@ const createDefaultParentComponent = (
   dirNameStr = tmpA[tmpA.length - 1];
   const compName = "project-name" in options ? options.projectName : dirNameStr;
   const parentComponent = {
-    group: options.projectGroup || "",
+    group: options.projectGroup || "_",
     name: compName,
     version: `${options.projectVersion}` || "latest",
     type:

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -6603,7 +6603,7 @@ export function parsePom(pomFile) {
   if (properties.groupId || properties.artifactId) {
     pomPurl = new PackageURL(
       "maven",
-      properties.groupId || "",
+      properties.groupId || "_",
       properties.artifactId,
       properties.version,
       { type: properties.packaging || "jar" },
@@ -7122,7 +7122,7 @@ function completeComponent(component) {
   component["type"] = component.group ? "library" : "application";
   const purl = new PackageURL(
     "maven",
-    component.group,
+    component.group || "_",
     component.name,
     component.version,
     { type: "jar" },
@@ -7820,7 +7820,7 @@ export function parseKVDep(rawOutput) {
       }
       const purlString = new PackageURL(
         "maven",
-        group,
+        group || "_",
         name,
         version,
         { type: "jar" },
@@ -16790,7 +16790,7 @@ export function parseSbtTree(sbtTreeFile) {
     }
     const purlString = new PackageURL(
       "maven",
-      group,
+      group || "_",
       name,
       version,
       { type: "jar" },
@@ -17718,7 +17718,7 @@ export async function collectJarNS(jarPath, pomPathMap = {}) {
         if (pomData) {
           const purlObj = new PackageURL(
             "maven",
-            pomData.groupId || "",
+            pomData.groupId || "_",
             pomData.artifactId,
             pomData.version,
             { type: "jar" },
@@ -17764,7 +17764,7 @@ export async function collectJarNS(jarPath, pomPathMap = {}) {
           }
           const purlObj = new PackageURL(
             "maven",
-            jarGroupName,
+            jarGroupName || "_",
             jarFileName.replace(`-${jarVersion}`, ""),
             jarVersion,
             { type: qualifierType },
@@ -17793,7 +17793,7 @@ export async function collectJarNS(jarPath, pomPathMap = {}) {
           }
           const purlObj = new PackageURL(
             "maven",
-            jarGroupName,
+            jarGroupName || "_",
             pkgName,
             jarVersion,
             { type: "jar" },
@@ -18441,7 +18441,7 @@ export async function extractJarArchive(jarFile, tempDir, jarNSMapping = {}) {
           ];
           const purl = new PackageURL(
             "maven",
-            group,
+            group || "_",
             name,
             version,
             { type: "jar" },
@@ -19669,7 +19669,7 @@ export async function buildObjectForGradleModule(name, metadata) {
     };
     const purl = new PackageURL(
       "maven",
-      component.group,
+      component.group || "_",
       component.name,
       component.version,
       { type: "jar" },

--- a/lib/helpers/utils.poku.js
+++ b/lib/helpers/utils.poku.js
@@ -11842,19 +11842,19 @@ it("parseMillDependency test", () => {
   const relations = new Map();
 
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/bar@latest?type=jar"),
+    dependencies.has("pkg:maven/_/bar@latest?type=jar"),
     false,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/bar.test@latest?type=jar"),
+    dependencies.has("pkg:maven/_/bar.test@latest?type=jar"),
     false,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/foo@latest?type=jar"),
+    dependencies.has("pkg:maven/_/foo@latest?type=jar"),
     false,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/foo.test@latest?type=jar"),
+    dependencies.has("pkg:maven/_/foo.test@latest?type=jar"),
     false,
   );
   assert.deepStrictEqual(dependencies.size, 0);
@@ -11862,19 +11862,19 @@ it("parseMillDependency test", () => {
 
   parseMillDependency("bar", dependencies, relations, millTestDataRoot);
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/bar@latest?type=jar"),
+    dependencies.has("pkg:maven/_/bar@latest?type=jar"),
     true,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/bar.test@latest?type=jar"),
+    dependencies.has("pkg:maven/_/bar.test@latest?type=jar"),
     false,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/foo@latest?type=jar"),
+    dependencies.has("pkg:maven/_/foo@latest?type=jar"),
     false,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/foo.test@latest?type=jar"),
+    dependencies.has("pkg:maven/_/foo.test@latest?type=jar"),
     false,
   );
   assert.deepStrictEqual(dependencies.size, 8);
@@ -11882,19 +11882,19 @@ it("parseMillDependency test", () => {
 
   parseMillDependency("bar.test", dependencies, relations, millTestDataRoot);
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/bar@latest?type=jar"),
+    dependencies.has("pkg:maven/_/bar@latest?type=jar"),
     true,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/bar.test@latest?type=jar"),
+    dependencies.has("pkg:maven/_/bar.test@latest?type=jar"),
     true,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/foo@latest?type=jar"),
+    dependencies.has("pkg:maven/_/foo@latest?type=jar"),
     false,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/foo.test@latest?type=jar"),
+    dependencies.has("pkg:maven/_/foo.test@latest?type=jar"),
     false,
   );
   assert.deepStrictEqual(dependencies.size, 13);
@@ -11902,19 +11902,19 @@ it("parseMillDependency test", () => {
 
   parseMillDependency("foo", dependencies, relations, millTestDataRoot);
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/bar@latest?type=jar"),
+    dependencies.has("pkg:maven/_/bar@latest?type=jar"),
     true,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/bar.test@latest?type=jar"),
+    dependencies.has("pkg:maven/_/bar.test@latest?type=jar"),
     true,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/foo@latest?type=jar"),
+    dependencies.has("pkg:maven/_/foo@latest?type=jar"),
     true,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/foo.test@latest?type=jar"),
+    dependencies.has("pkg:maven/_/foo.test@latest?type=jar"),
     false,
   );
   assert.deepStrictEqual(dependencies.size, 14);
@@ -11922,19 +11922,19 @@ it("parseMillDependency test", () => {
 
   parseMillDependency("foo.test", dependencies, relations, millTestDataRoot);
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/bar@latest?type=jar"),
+    dependencies.has("pkg:maven/_/bar@latest?type=jar"),
     true,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/bar.test@latest?type=jar"),
+    dependencies.has("pkg:maven/_/bar.test@latest?type=jar"),
     true,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/foo@latest?type=jar"),
+    dependencies.has("pkg:maven/_/foo@latest?type=jar"),
     true,
   );
   assert.deepStrictEqual(
-    dependencies.has("pkg:maven/foo.test@latest?type=jar"),
+    dependencies.has("pkg:maven/_/foo.test@latest?type=jar"),
     true,
   );
   assert.deepStrictEqual(dependencies.size, 15);


### PR DESCRIPTION
Maven PURLs were not correct for some jars, mostly local projects - 'namespace' ('groupId') is mandatory for maven PURLs

This issue was found when trying to upgrade the packageurl-js package.

This PR fixes this issue by using a constant '_' for missing groups. Users are advised to use the cdxgen parameter `--project-group` to use a sensible value.