### PR TITLE
[swift] Fixed incorrect PURLs

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -17394,7 +17394,7 @@ export function parseSwiftJsonTreeObject(
   } else {
     purl = new PackageURL(
       "swift",
-      "",
+      "localhost",
       jsonObject.name,
       jsonObject.version,
       null,

--- a/lib/helpers/utils.poku.js
+++ b/lib/helpers/utils.poku.js
@@ -10820,15 +10820,15 @@ it("parse swift deps files", () => {
   assert.deepStrictEqual(retData.pkgList.length, 5);
   assert.deepStrictEqual(retData.rootList[0], {
     name: "swift-markdown",
-    group: "",
-    purl: "pkg:swift/swift-markdown@unspecified",
+    group: "localhost",
+    purl: "pkg:swift/localhost/swift-markdown@unspecified",
     type: "application",
     version: "unspecified",
     properties: [
       { name: "SrcPath", value: "/Volumes/Work/sandbox/swift-markdown" },
       { name: "SrcFile", value: "./test/data/swift-deps.json" },
     ],
-    "bom-ref": "pkg:swift/swift-markdown@unspecified",
+    "bom-ref": "pkg:swift/localhost/swift-markdown@unspecified",
   });
   assert.deepStrictEqual(retData.pkgList[1], {
     "bom-ref": "pkg:swift/github.com/apple/swift-cmark@unspecified",
@@ -10854,7 +10854,7 @@ it("parse swift deps files", () => {
   assert.deepStrictEqual(
     retData.dependenciesList[retData.dependenciesList.length - 1],
     {
-      ref: "pkg:swift/swift-markdown@unspecified",
+      ref: "pkg:swift/localhost/swift-markdown@unspecified",
       dependsOn: [
         "pkg:swift/github.com/apple/swift-argument-parser@1.0.3",
         "pkg:swift/github.com/apple/swift-cmark@unspecified",
@@ -10870,8 +10870,8 @@ it("parse swift deps files", () => {
   assert.deepStrictEqual(retData.pkgList.length, 5);
   assert.deepStrictEqual(retData.rootList[0], {
     name: "swift-certificates",
-    group: "",
-    purl: "pkg:swift/swift-certificates@unspecified",
+    group: "localhost",
+    purl: "pkg:swift/localhost/swift-certificates@unspecified",
     version: "unspecified",
     type: "application",
     properties: [
@@ -10881,7 +10881,7 @@ it("parse swift deps files", () => {
       },
       { name: "SrcFile", value: "./test/data/swift-deps.json" },
     ],
-    "bom-ref": "pkg:swift/swift-certificates@unspecified",
+    "bom-ref": "pkg:swift/localhost/swift-certificates@unspecified",
   });
   assert.deepStrictEqual(retData.pkgList[1], {
     "bom-ref": "pkg:swift/github.com/apple/swift-crypto@2.4.0",
@@ -10911,7 +10911,7 @@ it("parse swift deps files", () => {
       dependsOn: ["pkg:swift/github.com/apple/swift-asn1@0.7.0"],
     },
     {
-      ref: "pkg:swift/swift-certificates@unspecified",
+      ref: "pkg:swift/localhost/swift-certificates@unspecified",
       dependsOn: ["pkg:swift/github.com/apple/swift-crypto@2.4.0"],
     },
   ]);


### PR DESCRIPTION
Swift PURLs were not correct: swift requires a "namespace" component, which should be the source host and user/organization.

This issue was found when trying to upgrade the packageurl-js package.

This PR fixes this issue by using the constant 'localhost' as the source host, a user is NOT set (but this is accepted by the packageurl library).