### PR TITLE
Native sbom attachment

### DIFF
--- a/.github/actions/generate-attach-sbom/action.yml
+++ b/.github/actions/generate-attach-sbom/action.yml
@@ -43,8 +43,7 @@ runs:
         tags_list=$(echo "$raw_tags" | tr ',' ' ' | tr '\n' ' ')
         for tag in $tags_list; do
           echo "Attaching SBOM to $tag"
-          oras attach --artifact-type sbom/cyclonedx --platform ${{ inputs.platform }} "$tag" ./sbom-oci-image.cdx.json:application/vnd.cyclonedx+json
-          oras discover --format tree --platform ${{ inputs.platform }} "$tag"
+          node bin/sign.js -i sbom-oci-image.cdx.json --attach "$tag"
           node bin/verify.js -i "$tag" --platform ${{ inputs.platform }} --public-key contrib/bom-signer/public.key
         done
         rm sbom-oci-image.cdx.json ${{ runner.temp }}/image.tar

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -923,8 +923,6 @@ jobs:
           ./contrib/free_disk_space.sh
       - name: Set up Docker BuildX
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
-      - name: Setup ORAS
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -1035,8 +1033,6 @@ jobs:
           ./contrib/free_disk_space.sh
       - name: Set up Docker BuildX
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
-      - name: Setup ORAS
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -181,7 +181,6 @@ jobs:
           node-version-file: .nvmrc
           package-manager-cache: false
           registry-url: https://registry.npmjs.org/
-      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
@@ -238,8 +237,7 @@ jobs:
           node bin/verify.js -i cdxgen-oci-image.cdx.json --public-key contrib/bom-signer/public.key
           for tag in $tags; do
             echo "Processing tag: $tag"
-            oras attach --artifact-type sbom/cyclonedx "$tag" ./cdxgen-oci-image.cdx.json:application/vnd.cyclonedx+json
-            oras discover --format tree "$tag"
+            node bin/sign.js -i cdxgen-oci-image.cdx.json --attach "$tag"
             node bin/verify.js -i "$tag" --public-key contrib/bom-signer/public.key
           done
         env:
@@ -275,7 +273,6 @@ jobs:
           node-version-file: .nvmrc
           package-manager-cache: false
           registry-url: https://registry.npmjs.org/
-      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
@@ -317,8 +314,7 @@ jobs:
           node bin/verify.js -i cdxgen-secure-oci-image.cdx.json --public-key contrib/bom-signer/public.key
           for tag in $tags; do
             echo "Processing tag: $tag"
-            oras attach --artifact-type sbom/cyclonedx "$tag" ./cdxgen-secure-oci-image.cdx.json:application/vnd.cyclonedx+json
-            oras discover --format tree "$tag"
+            node bin/sign.js -i cdxgen-secure-oci-image.cdx.json --attach "$tag"
             node bin/verify.js -i "$tag" --public-key contrib/bom-signer/public.key
           done
         env:
@@ -354,7 +350,6 @@ jobs:
           node-version-file: .nvmrc
           package-manager-cache: false
           registry-url: https://registry.npmjs.org/
-      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
@@ -399,8 +394,7 @@ jobs:
           node bin/verify.js -i cdxgen-deno-oci-image.cdx.json --public-key contrib/bom-signer/public.key
           for tag in $tags; do
             echo "Processing tag: $tag"
-            oras attach --artifact-type sbom/cyclonedx "$tag" ./cdxgen-deno-oci-image.cdx.json:application/vnd.cyclonedx+json
-            oras discover --format tree "$tag"
+            node bin/sign.js -i cdxgen-deno-oci-image.cdx.json --attach "$tag"
             node bin/verify.js -i "$tag" --public-key contrib/bom-signer/public.key
           done
         env:
@@ -434,7 +428,6 @@ jobs:
           node-version-file: .nvmrc
           package-manager-cache: false
           registry-url: https://registry.npmjs.org/
-      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
@@ -488,7 +481,6 @@ jobs:
           node-version-file: .nvmrc
           package-manager-cache: false
           registry-url: https://registry.npmjs.org/
-      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
@@ -534,8 +526,7 @@ jobs:
           node bin/verify.js -i cdxgen-bun-oci-image.cdx.json --public-key contrib/bom-signer/public.key
           for tag in $tags; do
             echo "Processing tag: $tag"
-            oras attach --artifact-type sbom/cyclonedx "$tag" ./cdxgen-bun-oci-image.cdx.json:application/vnd.cyclonedx+json
-            oras discover --format tree "$tag"
+            node bin/sign.js -i cdxgen-bun-oci-image.cdx.json --attach "$tag"
             node bin/verify.js -i "$tag" --public-key contrib/bom-signer/public.key
           done
         env:

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -222,6 +222,7 @@ jobs:
             "./lib/helpers",
             "./bin",
             "./lib/audit",
+            "./lib/managers",
           ]);
           const inventory = {};
           for (const target of targets) {
@@ -246,10 +247,10 @@ jobs:
           );
           EOF
           jq -e 'any(.["./lib/helpers"][]; .type == "cryptographic-asset" and .name == "sha-256" and .cryptoProperties.assetType == "algorithm" and any((.properties // [])[]; .name == "cdx:crypto:sourceType" and .value == "js-ast:node:crypto.createHash") and ((.evidence.identity // []) | length) > 0 and .evidence.identity[0].field == "name" and ((.evidence.identity[0].methods // []) | length) > 0 and ((.evidence.occurrences // []) | length) > 0)' bomresults/bom-cdxgen-self-source-cbom.json
-          jq -e '([.["./lib/helpers"][], .["./bin"][], .["./lib/audit"][]]) | all(.[]?; .type != "cryptographic-asset" or ((.cryptoProperties.assetType // "") != "algorithm") or (all((.evidence.occurrences // [])[]?; .location != null and (.line? == null or (.line | type == "number")) and (.offset? == null))))' bomresults/bom-cdxgen-self-source-cbom.json
-          jq -e '([.["./lib/helpers"][], .["./bin"][], .["./lib/audit"][]]) | all(.[]?; .type != "cryptographic-asset" or ((.cryptoProperties.assetType // "") != "algorithm") or ((((.evidence.identity // []) | length) > 0) and (((.evidence.occurrences // []) | length) > 0)))' bomresults/bom-cdxgen-self-source-cbom.json
-          jq -e '((.["./bin"] | length) > 0) and ((.["./lib/audit"] | length) > 0)' bomresults/bom-cdxgen-self-source-cbom.json
-          jq -e '((.["./lib/stages"] | length) == 0) and ((.["./lib/server"] | length) == 0) and ((.["./lib/managers"] | length) == 0) and ((.["./lib/evinser"] | length) == 0) and ((.["./lib/parsers"] | length) == 0)' bomresults/bom-cdxgen-self-source-cbom.json
+          jq -e '([.["./lib/helpers"][], .["./bin"][], .["./lib/audit"][], .["./lib/managers"][]]) | all(.[]?; .type != "cryptographic-asset" or ((.cryptoProperties.assetType // "") != "algorithm") or (all((.evidence.occurrences // [])[]?; .location != null and (.line? == null or (.line | type == "number")) and (.offset? == null))))' bomresults/bom-cdxgen-self-source-cbom.json
+          jq -e '([.["./lib/helpers"][], .["./bin"][], .["./lib/audit"][], .["./lib/managers"][]]) | all(.[]?; .type != "cryptographic-asset" or ((.cryptoProperties.assetType // "") != "algorithm") or ((((.evidence.identity // []) | length) > 0) and (((.evidence.occurrences // []) | length) > 0)))' bomresults/bom-cdxgen-self-source-cbom.json
+          jq -e '((.["./bin"] | length) > 0) and ((.["./lib/audit"] | length) > 0) and ((.["./lib/managers"] | length) > 0)' bomresults/bom-cdxgen-self-source-cbom.json
+          jq -e '((.["./lib/stages"] | length) == 0) and ((.["./lib/server"] | length) == 0) and ((.["./lib/evinser"] | length) == 0) and ((.["./lib/parsers"] | length) == 0)' bomresults/bom-cdxgen-self-source-cbom.json
         shell: bash
       - name: repotests cache-disable fixture
         run: |

--- a/bin/repl.js
+++ b/bin/repl.js
@@ -470,7 +470,7 @@ export const importSbom = async (sbomOrPath) => {
     printSummary(sbom);
   } else if (isSupportedSbomRegistryReference(importTarget)) {
     try {
-      sbom = getBomWithOras(importTarget);
+      sbom = await getBomWithOras(importTarget);
       if (sbom) {
         printSummary(sbom);
       } else {

--- a/bin/sign.js
+++ b/bin/sign.js
@@ -11,7 +11,11 @@ import {
   getNonCycloneDxErrorMessage,
   isCycloneDxBom,
 } from "../lib/helpers/bomUtils.js";
-import { retrieveCdxgenVersion, safeExistsSync } from "../lib/helpers/utils.js";
+import {
+  readEnvironmentVariable,
+  retrieveCdxgenVersion,
+  safeExistsSync,
+} from "../lib/helpers/utils.js";
 
 const _yargs = yargs(hideBin(process.argv));
 
@@ -31,12 +35,12 @@ const args = _yargs
   })
   .option("algorithm", {
     alias: "a",
-    default: "RS512",
+    default: readEnvironmentVariable("SBOM_SIGN_ALGORITHM") || "RS512",
     description: "JSF Signature Algorithm (e.g., RS512, ES256, Ed25519).",
   })
   .option("mode", {
     alias: "m",
-    default: "replace",
+    default: readEnvironmentVariable("SBOM_SIGN_MODE") || "replace",
     choices: ["replace", "signers", "chain"],
     description:
       "Signature mode. Use 'signers' for multi-signing, 'chain' for sequential chaining.",
@@ -63,6 +67,11 @@ const args = _yargs
     description:
       "Sign granular annotations. Disable (--no-sign-annotations) when appending multi-signatures.",
   })
+  .option("attach", {
+    type: "string",
+    description:
+      "Attach the signed SBOM to the specified OCI image reference natively.",
+  })
   .scriptName("cdx-sign")
   .version(retrieveCdxgenVersion())
   .help()
@@ -73,36 +82,113 @@ if (!safeExistsSync(args.input)) {
   process.exit(1);
 }
 
-if (!safeExistsSync(args.privateKey)) {
-  console.error(`Private key file '${args.privateKey}' not found.`);
-  process.exit(1);
+let hasPrivateKey = false;
+let privateKeyContent = null;
+
+const envPrivateKeyFile = readEnvironmentVariable("SBOM_SIGN_PRIVATE_KEY", {
+  sensitive: true,
+});
+const envPrivateKeyBase64 = readEnvironmentVariable(
+  "SBOM_SIGN_PRIVATE_KEY_BASE64",
+  {
+    sensitive: true,
+  },
+);
+
+if (args.privateKey) {
+  if (safeExistsSync(args.privateKey)) {
+    privateKeyContent = fs.readFileSync(args.privateKey, "utf8");
+    hasPrivateKey = true;
+  } else {
+    console.error(`Private key file '${args.privateKey}' not found.`);
+    process.exit(1);
+  }
+} else if (envPrivateKeyFile) {
+  if (safeExistsSync(envPrivateKeyFile)) {
+    privateKeyContent = fs.readFileSync(envPrivateKeyFile, "utf8");
+    hasPrivateKey = true;
+  } else {
+    console.error(
+      `Private key file '${envPrivateKeyFile}' from SBOM_SIGN_PRIVATE_KEY environment variable not found.`,
+    );
+    process.exit(1);
+  }
+} else if (envPrivateKeyBase64) {
+  try {
+    privateKeyContent = Buffer.from(envPrivateKeyBase64, "base64").toString(
+      "utf8",
+    );
+    hasPrivateKey = true;
+  } catch {
+    console.error(
+      "Failed to decode SBOM_SIGN_PRIVATE_KEY_BASE64 environment variable.",
+    );
+    process.exit(1);
+  }
+}
+
+function hasAnySignature(bomJson) {
+  if (bomJson.signature) return true;
+  if (
+    Array.isArray(bomJson.components) &&
+    bomJson.components.some((c) => c.signature)
+  )
+    return true;
+  if (
+    Array.isArray(bomJson.services) &&
+    bomJson.services.some((s) => s.signature)
+  )
+    return true;
+  if (
+    Array.isArray(bomJson.annotations) &&
+    bomJson.annotations.some((a) => a.signature)
+  )
+    return true;
+  return false;
 }
 
 try {
   const bomJson = JSON.parse(fs.readFileSync(args.input, "utf8"));
-  const privateKey = fs.readFileSync(args.privateKey, "utf8");
   if (!isCycloneDxBom(bomJson)) {
     console.error(getNonCycloneDxErrorMessage(bomJson, "cdx-sign"));
     process.exit(1);
   }
 
-  const signedBom = signBom(bomJson, {
-    privateKey,
-    algorithm: args.algorithm,
-    keyId: args.keyId,
-    mode: args.mode,
-    signComponents: args.signComponents,
-    signServices: args.signServices,
-    signAnnotations: args.signAnnotations,
-  });
+  let signedBom = bomJson;
+  if (hasPrivateKey && privateKeyContent) {
+    signedBom = signBom(bomJson, {
+      privateKey: privateKeyContent,
+      algorithm: args.algorithm,
+      keyId: args.keyId,
+      mode: args.mode,
+      signComponents: args.signComponents,
+      signServices: args.signServices,
+      signAnnotations: args.signAnnotations,
+    });
 
-  const outputPath = args.output || args.input;
-  fs.writeFileSync(outputPath, JSON.stringify(signedBom, null, null));
+    const outputPath = args.output || args.input;
+    fs.writeFileSync(outputPath, JSON.stringify(signedBom, null, null));
 
-  console.log(`Successfully signed BOM and saved to '${outputPath}'`);
-  console.log(
-    `Mode: ${args.mode} | Algorithm: ${args.algorithm}${args.keyId ? ` | KeyId: ${args.keyId}` : ""}`,
-  );
+    console.log(`Successfully signed BOM and saved to '${outputPath}'`);
+    console.log(
+      `Mode: ${args.mode} | Algorithm: ${args.algorithm}${args.keyId ? ` | KeyId: ${args.keyId}` : ""}`,
+    );
+  } else {
+    if (!hasAnySignature(bomJson)) {
+      console.error(
+        "Private key not provided, and the BOM does not contain any signatures.",
+      );
+      process.exit(1);
+    }
+    console.log(
+      "Private key not provided. BOM contains existing signature(s); skipping signing step.",
+    );
+  }
+
+  if (args.attach) {
+    const { attachBomNative } = await import("../lib/managers/oci.js");
+    await attachBomNative(args.attach, signedBom);
+  }
 } catch (error) {
   console.error("SBOM signing failed:", error.message);
   process.exit(1);

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -154,7 +154,7 @@ async function loadBom(input, platform) {
     input.includes("docker") ||
     input.includes("ghcr")
   ) {
-    const bom = getBomWithOras(input, platform);
+    const bom = await getBomWithOras(input, platform);
     if (bom) return bom;
   }
   console.error(`Input '${input}' is not a readable SBOM.`);

--- a/bin/verify.js
+++ b/bin/verify.js
@@ -97,7 +97,7 @@ async function getBom(args) {
     args.input.includes("docker") ||
     args.input.includes("ghcr")
   ) {
-    return getBomWithOras(args.input, args.platform);
+    return await getBomWithOras(args.input, args.platform);
   }
   return undefined;
 }

--- a/data/rules/container-risk.yaml
+++ b/data/rules/container-risk.yaml
@@ -275,3 +275,79 @@
       "knowledgeSources": $prop($, 'cdx:container:knowledgeSources'),
       "srcFile": $prop($, 'SrcFile')
     }
+
+- id: CTR-008
+  name: "Container dependency relies on the mutable 'latest' tag"
+  description: "Using the 'latest' tag for container image dependencies undermines supply chain reproducibility and makes SBOM attestations fragile since the underlying image can change without notice."
+  severity: medium
+  category: container-risk
+  dry-run-support: full
+  condition: |
+    components[
+      type = 'container'
+      and (
+        $contains(name, ':latest') or $contains(version, 'latest') or $not($exists(version)) or version = ''
+      )
+    ]
+  location: |
+    {
+      "bomRef": $."bom-ref",
+      "purl": purl
+    }
+  message: "Container component '{{ name }}' uses the mutable 'latest' tag or lacks a pinned version"
+  mitigation: "Pin the container dependency to a specific immutable digest (e.g., using @sha256:...) or a stable release tag to ensure reproducibility and reliable attestations."
+  evidence: |
+    {
+      "name": name,
+      "version": version,
+      "purl": purl
+    }
+
+- id: CTR-009
+  name: "Container dependency lacks attached SBOM"
+  description: "Container dependencies should have an attached SBOM (attestation) in the container registry to verify their software bill of materials."
+  severity: medium
+  category: container-risk
+  dry-run-support: full
+  condition: |
+    components[
+      type = 'container'
+      and $not($hasSbom($))
+    ]
+  location: |
+    {
+      "bomRef": $."bom-ref",
+      "purl": purl
+    }
+  message: "Container component '{{ name }}' lacks an attached SBOM in the registry"
+  mitigation: "Generate an SBOM and attach it to the container image using the attach feature (cdx-sign --attach)."
+  evidence: |
+    {
+      "name": name,
+      "purl": purl
+    }
+
+- id: CTR-010
+  name: "Container dependency lacks signed SBOM attestation"
+  description: "Container dependencies should have a cryptographically signed SBOM attestation in the container registry to ensure authenticity and integrity."
+  severity: medium
+  category: container-risk
+  dry-run-support: full
+  condition: |
+    components[
+      type = 'container'
+      and $hasSbom($)
+      and $not($hasSignedSbom($))
+    ]
+  location: |
+    {
+      "bomRef": $."bom-ref",
+      "purl": purl
+    }
+  message: "Container component '{{ name }}' lacks a signed SBOM attestation in the registry"
+  mitigation: "Sign the container SBOM using a private key and attach the signed version to the registry (cdx-sign -k private.key --attach <tag>)."
+  evidence: |
+    {
+      "name": name,
+      "purl": purl
+    }

--- a/docs/BOM_AUDIT.md
+++ b/docs/BOM_AUDIT.md
@@ -59,6 +59,8 @@ cdx-audit --bom bom.evinse.json --direct-bom-audit --categories golem
 
 For Go projects, run `evinse -l go --deep` or `evinse -l go --with-data-flow --golem-dataflow crypto` before `cdx-audit` when you want Golem data-flow and crypto-flow properties such as `cdx:golem:dataFlowSliceCount`, `cdx:golem:cryptoDataFlow`, and `cdx:golem:cryptoDataFlowCount` to participate in review and prioritization.
 
+> **Note:** `cdxgen` supports reading both OCI Referrers and BuildKit `in-toto` attestations natively. When working with container images, you can directly pass the OCI image reference to tools like `cdx-validate` and `cdx-verify` to automatically fetch and evaluate attached SBOMs.
+
 > **Note:** `--bom-audit` automatically enables `--include-formulation` to collect CI/CD workflow data. For AI/ML scans, this also emits the discovered AI and agentic inventory in the formal CycloneDX `formulation[]` section. The formulation section may include sensitive data such as emails and environment details. Always review the generated SBOM before distribution.
 
 ## Dry-run mode
@@ -553,6 +555,7 @@ When a finding or count summary needs manual follow-up, import the BOM into `cdx
 | CTR-005 | medium   | Container image includes mutable-path remote-execution helper       |
 | CTR-006 | high     | Container image ships dedicated offensive container toolkit         |
 | CTR-007 | medium   | Container image includes seccomp-sensitive namespace escape helper  |
+| CTR-008 | medium   | Container dependency relies on the mutable 'latest' tag             |
 
 ### `vscode-extension` — VS Code Extension Security
 

--- a/docs/CDX_SIGN.md
+++ b/docs/CDX_SIGN.md
@@ -28,17 +28,29 @@ cdx-sign -i bom.json -k approver_private.pem --mode chain
 
 ## CLI reference
 
-| Flag                                           | Default         | Description                                                    |
-| ---------------------------------------------- | --------------- | -------------------------------------------------------------- |
-| `-i, --input`                                  | `bom.json`      | Input CycloneDX JSON BOM to sign                               |
-| `-o, --output`                                 | overwrite input | Output file path                                               |
-| `-k, --private-key`                            | required        | PEM-encoded private key                                        |
-| `-a, --algorithm`                              | `RS512`         | JSF signature algorithm such as `RS512`, `ES256`, or `Ed25519` |
-| `-m, --mode`                                   | `replace`       | Signature mode: `replace`, `signers`, or `chain`               |
-| `--key-id`                                     | —               | Optional `keyId` embedded in the signature                     |
-| `--sign-components` / `--no-sign-components`   | on              | Sign nested components                                         |
-| `--sign-services` / `--no-sign-services`       | on              | Sign nested services                                           |
-| `--sign-annotations` / `--no-sign-annotations` | on              | Sign nested annotations                                        |
+| Flag                                           | Default         | Description                                                                                              |
+| ---------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------- |
+| `-i, --input`                                  | `bom.json`      | Input CycloneDX JSON BOM to sign                                                                         |
+| `-o, --output`                                 | overwrite input | Output file path                                                                                         |
+| `-k, --private-key`                            | —               | PEM-encoded private key file path. Optional if loaded from env                                           |
+| `-a, --algorithm`                              | `RS512`         | JSF signature algorithm such as `RS512`, `ES256`, or `Ed25519`. Defaults to `SBOM_SIGN_ALGORITHM` if set |
+| `-m, --mode`                                   | `replace`       | Signature mode: `replace`, `signers`, or `chain`. Defaults to `SBOM_SIGN_MODE` if set                    |
+| `--key-id`                                     | —               | Optional `keyId` embedded in the signature                                                               |
+| `--sign-components` / `--no-sign-components`   | on              | Sign nested components                                                                                   |
+| `--sign-services` / `--no-sign-services`       | on              | Sign nested services                                                                                     |
+| `--sign-annotations` / `--no-sign-annotations` | on              | Sign nested annotations                                                                                  |
+| `--attach`                                     | —               | OCI image tag reference to natively attach the signed SBOM to                                            |
+
+Note: A private key is not required if the input BOM is already signed and you only use the `--attach` feature to upload it to an OCI registry.
+
+## Environment variables
+
+Instead of passing CLI options, `cdx-sign` can read key configurations from environment variables:
+
+- `SBOM_SIGN_PRIVATE_KEY` — File path to the PEM-encoded private key
+- `SBOM_SIGN_PRIVATE_KEY_BASE64` — Base64-encoded content of the PEM private key
+- `SBOM_SIGN_ALGORITHM` — JSF signature algorithm
+- `SBOM_SIGN_MODE` — Signature mode
 
 ## Signature modes
 
@@ -61,12 +73,30 @@ Use when each signer is expected to sign the result of the previous signer, crea
 - When appending multi-signatures with `--mode signers`, disable nested signing unless every participant is expected to resign nested objects too.
 - Pair `cdx-sign` with [`cdx-verify`](CDX_VERIFY.md) in CI so signing failures or mismatched public keys are caught immediately.
 
-## Example release flow
+## Examples
+
+### Local signing
 
 ```shell
 cdxgen -o bom.json .
 cdx-sign -i bom.json -k builder_private.pem --key-id builder-ci
 cdx-verify -i bom.json --public-key builder_public.pem
+```
+
+### Native container SBOM attestation
+
+Generate a signed SBOM, attach it natively to an OCI registry tag, and verify the registry reference natively:
+
+```shell
+# Generate and sign automatically via cdxgen using base64 env secret
+export SBOM_SIGN_PRIVATE_KEY_BASE64="LS0tLS1CRUdJTi..."
+cdxgen -t docker -o bom.json my-app:latest
+
+# Attach the signed SBOM to the registry tag natively
+cdx-sign -i bom.json --attach my-app:latest
+
+# Verify the attached SBOM in the registry natively
+cdx-verify -i my-app:latest --public-key public.pem
 ```
 
 ## Related docs

--- a/docs/CDX_VALIDATE.md
+++ b/docs/CDX_VALIDATE.md
@@ -49,8 +49,8 @@ cdx-validate -i bom.json -r json --fail-severity medium
 
 | Flag                                       | Default    | Description                                                                                                                   |
 | ------------------------------------------ | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `-i, --input`                              | `bom.json` | Local SBOM JSON/protobuf path or an OCI reference (resolved with `oras`).                                                     |
-| `--platform`                               | —          | Platform to pass to `oras` when the input is an OCI ref.                                                                      |
+| `-i, --input`                              | `bom.json` | Local SBOM JSON/protobuf path or an OCI reference (resolved natively without `oras`).                                         |
+| `--platform`                               | —          | Platform to pass when the input is an OCI ref.                                                                                |
 | `-r, --report`                             | `console`  | `console`, `json`, `sarif`, `annotations`.                                                                                    |
 | `-o, --report-file`                        | stdout     | Write the report to a file.                                                                                                   |
 | `--schema` / `--no-schema`                 | on         | Toggle JSON-schema validation.                                                                                                |

--- a/docs/LESSON3.md
+++ b/docs/LESSON3.md
@@ -8,7 +8,6 @@ In this lesson, we will learn about signing and attaching a signed SBOM to a con
 
 Ensure the following tools are installed.
 
-- ORAS [CLI](https://oras.land/docs/installation)
 - Node.js > 20
 - docker or podman
 
@@ -40,15 +39,19 @@ docker push docker.io/<repo>/sign-test:latest
 ### Create an SBOM with cdxgen
 
 ```shell
-cdxgen --generate-key-and-sign -t docker -o bom.json docker.io/<repo>/sign-test:latest
-oras attach --artifact-type sbom/cyclonedx docker.io/<repo>/sign-test:latest ./bom.json:application/vnd.cyclonedx+json
-oras discover --format tree docker.io/<repo>/sign-test:latest
+# Generate an SBOM
+cdxgen -t docker -o bom.json docker.io/<repo>/sign-test:latest
+
+# Generate a private key for signing
+openssl genpkey -algorithm RSA -out private.key -pkeyopt rsa_keygen_bits:2048
+
+# Sign the SBOM and attach it natively to the OCI image
+cdx-sign --input bom.json --private-key private.key --attach docker.io/<repo>/sign-test:latest
 ```
 
-To download the SBOM attachment from the OCI image, use the `oras pull` command with the correct digest from the `discover` command.
+To download and validate the SBOM attachment from the OCI image natively, use the `cdx-validate` or `cdx-verify` command directly with the image reference. `cdxgen` handles the OCI referrers API and fallback tags automatically.
 
 ```shell
-IMAGE_REF=$(oras discover --format json --artifact-type sbom/cyclonedx docker.io/<repo>/sign-test:latest | jq -r '.manifests[0].reference')
-oras pull $IMAGE_REF -o sbom_output_dir
-ls -l sbom_output_dir/bom.json
+# Pull the attached SBOM and validate it
+cdx-validate -i docker.io/<repo>/sign-test:latest
 ```

--- a/lib/managers/oci.js
+++ b/lib/managers/oci.js
@@ -1,14 +1,11 @@
 import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
-import { arch } from "node:os";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { isCycloneDxBom } from "../helpers/bomUtils.js";
-import {
-  getAllFiles,
-  getTmpDir,
-  isWin,
-  safeSpawnSync,
-} from "../helpers/utils.js";
+import { cdxgenAgent, getAllFiles, safeExistsSync } from "../helpers/utils.js";
 
 const ORAS_CREATED_ANNOTATION = "org.opencontainers.image.created";
 
@@ -93,7 +90,7 @@ function selectManifestImageRef(image, manifestObj) {
   return candidates[0]?.imageRef;
 }
 
-function getBomFiles(tmpDir) {
+function _getBomFiles(tmpDir) {
   let bomFiles = getAllFiles(tmpDir, "**/*.{bom,cdx}.json");
   if (!bomFiles.length) {
     bomFiles = getAllFiles(tmpDir, "**/bom.json");
@@ -104,76 +101,497 @@ function getBomFiles(tmpDir) {
   return bomFiles;
 }
 
-/**
- * Retrieves a CycloneDX BOM attached to an OCI image using the `oras` CLI tool.
- * Discovers SBOM attachments via `oras discover`, pulls the first matching
- * artifact, and returns the parsed BOM JSON. Retries automatically with a
- * platform-specific manifest when the initial platform-agnostic discovery fails.
- *
- * @param {string} image OCI image reference (e.g. `"registry.example.com/org/app:tag"`)
- * @param {string} [platform] OCI platform string (e.g. `"linux/amd64"`); detected automatically when omitted
- * @returns {Object|undefined} Parsed CycloneDX BOM JSON object, or `undefined` if not found
- */
-export function getBomWithOras(image, platform = undefined) {
-  const platformArch = arch() === "arm64" ? "arm64" : "amd64";
-  let parameters = [
-    "discover",
-    "--format",
-    "json",
-    "--artifact-type",
-    "sbom/cyclonedx",
-  ];
-  if (platform) {
-    parameters = parameters.concat(["--platform", platform]);
-  }
-  let result = safeSpawnSync("oras", parameters.concat([image]), {
-    shell: isWin,
-  });
-  if (result.status !== 0 || result.error) {
-    if (!platform) {
-      return getBomWithOras(image, `linux/${platformArch}`);
+function parseImageRef(image) {
+  let registry = "docker.io";
+  let repoAndTag = image;
+  const firstSlash = image.indexOf("/");
+  if (firstSlash !== -1) {
+    const hostCandidate = image.slice(0, firstSlash);
+    if (
+      hostCandidate.includes(".") ||
+      hostCandidate.includes(":") ||
+      hostCandidate === "localhost"
+    ) {
+      registry = hostCandidate;
+      repoAndTag = image.slice(firstSlash + 1);
     }
-    console.log(
-      "Install oras by following the instructions at: https://oras.land/docs/installation",
-    );
-    if (result.stderr) {
-      console.log(result.stderr);
-    }
-    return undefined;
   }
-  if (result.stdout) {
-    const out = Buffer.from(result.stdout).toString();
-    try {
-      const manifestObj = JSON.parse(out);
-      const imageRef = selectManifestImageRef(image, manifestObj);
-      if (imageRef) {
-        const tmpDir = getTmpDir();
-        result = safeSpawnSync("oras", ["pull", imageRef, "-o", tmpDir], {
-          shell: isWin,
-        });
-        if (result.status !== 0 || result.error) {
-          console.log(
-            `Unable to pull the SBOM attachment for ${imageRef} with oras!`,
-          );
-          return undefined;
+  let repository = repoAndTag;
+  let reference = "latest";
+  const atIndex = repoAndTag.indexOf("@");
+  if (atIndex !== -1) {
+    repository = repoAndTag.slice(0, atIndex);
+    reference = repoAndTag.slice(atIndex + 1);
+  } else {
+    const colonIndex = repoAndTag.lastIndexOf(":");
+    if (colonIndex !== -1) {
+      repository = repoAndTag.slice(0, colonIndex);
+      reference = repoAndTag.slice(colonIndex + 1);
+    }
+  }
+  if (registry === "docker.io" && !repository.includes("/")) {
+    repository = `library/${repository}`;
+  }
+  return { registry, repository, reference };
+}
+
+function getDockerCreds(registry) {
+  try {
+    const configPath = join(homedir(), ".docker", "config.json");
+    if (safeExistsSync(configPath)) {
+      const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+      if (config.auths) {
+        const auth =
+          config.auths[registry] ||
+          config.auths[`https://${registry}`] ||
+          config.auths[`https://${registry}/v1/`];
+        if (auth?.auth) {
+          return auth.auth;
         }
-        const bomFiles = getBomFiles(tmpDir);
-        for (const bomFile of bomFiles) {
-          try {
-            const bomJson = JSON.parse(fs.readFileSync(bomFile, "utf8"));
-            if (isCycloneDxBom(bomJson)) {
-              return bomJson;
-            }
-          } catch {
-            // Ignore unrelated or malformed JSON files pulled alongside the SBOM.
+      }
+    }
+  } catch (_e) {
+    /* ignore */
+  }
+  return process.env.DOCKER_AUTH;
+}
+
+async function getOciToken(registry, repository, scope) {
+  const creds = getDockerCreds(registry);
+  const scheme = registry.startsWith("localhost") ? "http" : "https";
+  const authUrl = `${scheme}://${registry}/v2/`;
+  try {
+    const res = await cdxgenAgent.get(authUrl, { throwHttpErrors: false });
+    if (res.statusCode === 401) {
+      const wwwAuth = res.headers["www-authenticate"];
+      if (wwwAuth?.toLowerCase().startsWith("bearer ")) {
+        const params = {};
+        wwwAuth
+          .substring(7)
+          .split(",")
+          .forEach((part) => {
+            const [k, v] = part.split("=");
+            if (v) params[k.trim()] = v.trim().replace(/"/g, "");
+          });
+        if (params.realm) {
+          const reqUrl = new URL(params.realm);
+          if (params.service)
+            reqUrl.searchParams.set("service", params.service);
+          reqUrl.searchParams.set("scope", `repository:${repository}:${scope}`);
+          const options = { responseType: "json" };
+          if (creds) {
+            options.headers = { Authorization: `Basic ${creds}` };
+          }
+          const tokenRes = await cdxgenAgent.get(reqUrl.toString(), options);
+          if (
+            tokenRes.body &&
+            (tokenRes.body.token || tokenRes.body.access_token)
+          ) {
+            return tokenRes.body.token || tokenRes.body.access_token;
           }
         }
-      } else {
-        console.log(`${image} does not contain any SBOM attachment!`);
       }
-    } catch (e) {
-      console.log(e);
     }
+  } catch (_e) {
+    /* ignore */
+  }
+  if (creds) return `Basic ${creds}`;
+  return null;
+}
+
+async function fetchManifest(registry, repository, reference, token) {
+  const scheme = registry.startsWith("localhost") ? "http" : "https";
+  const url = `${scheme}://${registry}/v2/${repository}/manifests/${reference}`;
+  const headers = {
+    Accept:
+      "application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.index.v1+json",
+  };
+  if (token) {
+    headers.Authorization = token.startsWith("Basic")
+      ? token
+      : `Bearer ${token}`;
+  }
+  const res = await cdxgenAgent.get(url, {
+    headers,
+    responseType: "json",
+    throwHttpErrors: false,
+  });
+  if (res.statusCode === 200) {
+    return {
+      manifest: res.body,
+      digest: res.headers["docker-content-digest"],
+      mediaType: res.headers["content-type"],
+    };
+  }
+  return null;
+}
+
+async function discoverReferrers(registry, repository, digest, token) {
+  const scheme = registry.startsWith("localhost") ? "http" : "https";
+  const url = `${scheme}://${registry}/v2/${repository}/referrers/${digest}?artifactType=application/vnd.cyclonedx+json`;
+  const headers = {};
+  if (token) {
+    headers.Authorization = token.startsWith("Basic")
+      ? token
+      : `Bearer ${token}`;
+  }
+  try {
+    const res = await cdxgenAgent.get(url, {
+      headers,
+      responseType: "json",
+      throwHttpErrors: false,
+    });
+    if (res.statusCode === 200) {
+      return res.body;
+    }
+  } catch (_e) {
+    /* ignore */
   }
   return undefined;
+}
+
+async function pullBlob(registry, repository, digest, token) {
+  const scheme = registry.startsWith("localhost") ? "http" : "https";
+  const url = `${scheme}://${registry}/v2/${repository}/blobs/${digest}`;
+  const headers = {};
+  if (token) {
+    headers.Authorization = token.startsWith("Basic")
+      ? token
+      : `Bearer ${token}`;
+  }
+  const res = await cdxgenAgent.get(url, { headers, responseType: "buffer" });
+  return res.body;
+}
+
+/**
+ * Retrieves a CycloneDX BOM attached to an OCI image purely in JavaScript
+ * without relying on the `oras` CLI tool.
+ *
+ * @param {string} image OCI image reference (e.g. `"registry.example.com/org/app:tag"`)
+ * @param {string} [platform] OCI platform string (e.g. `"linux/amd64"`); no-op for JS implementation
+ * @returns {Promise<Object|undefined>} Parsed CycloneDX BOM JSON object, or `undefined` if not found
+ */
+export async function getBomWithOras(image, _platform = undefined) {
+  const { registry, repository, reference } = parseImageRef(image);
+  const token = await getOciToken(registry, repository, "pull");
+
+  try {
+    const targetManifest = await fetchManifest(
+      registry,
+      repository,
+      reference,
+      token,
+    );
+    if (!targetManifest?.digest) {
+      return undefined;
+    }
+    const digest = targetManifest.digest;
+
+    let referrersObj = await discoverReferrers(
+      registry,
+      repository,
+      digest,
+      token,
+    );
+
+    // If not found with artifactType filter, try fetching all referrers
+    if (!referrersObj?.manifests || referrersObj.manifests.length === 0) {
+      const scheme = registry.startsWith("localhost") ? "http" : "https";
+      let url = `${scheme}://${registry}/v2/${repository}/referrers/${digest}`;
+      const headers = token
+        ? {
+            Authorization: token.startsWith("Basic")
+              ? token
+              : `Bearer ${token}`,
+          }
+        : {};
+      let res = await cdxgenAgent.get(url, {
+        headers,
+        responseType: "json",
+        throwHttpErrors: false,
+      });
+      if (res.statusCode === 200) {
+        referrersObj = res.body;
+      } else if (res.statusCode === 404 || res.statusCode === 400) {
+        // Fallback to OCI referrers tag schema
+        const fallbackTag = digest.replace(":", "-");
+        url = `${scheme}://${registry}/v2/${repository}/manifests/${fallbackTag}`;
+        headers.Accept = "application/vnd.oci.image.index.v1+json";
+        res = await cdxgenAgent.get(url, {
+          headers,
+          responseType: "json",
+          throwHttpErrors: false,
+        });
+        if (res.statusCode === 200) {
+          referrersObj = res.body;
+        }
+      }
+    }
+
+    let imageRef = selectManifestImageRef(image, referrersObj);
+
+    if (!imageRef && referrersObj?.manifests) {
+      for (const m of referrersObj.manifests) {
+        if (
+          m.artifactType === "application/vnd.cyclonedx+json" ||
+          m.artifactType === "sbom/cyclonedx"
+        ) {
+          imageRef = `${repository}@${m.digest}`;
+          break;
+        }
+      }
+    }
+
+    if (imageRef) {
+      const refParsed = parseImageRef(imageRef);
+      const manifestNode = await fetchManifest(
+        refParsed.registry,
+        refParsed.repository,
+        refParsed.reference,
+        token,
+      );
+      if (
+        manifestNode?.manifest?.layers &&
+        manifestNode.manifest.layers.length > 0
+      ) {
+        const layerDigest = manifestNode.manifest.layers[0].digest;
+        const blob = await pullBlob(
+          registry,
+          refParsed.repository,
+          layerDigest,
+          token,
+        );
+        let bomJson = JSON.parse(blob.toString("utf8"));
+
+        // Extract from in-toto envelope (BuildKit native attestations)
+        if (
+          bomJson &&
+          (bomJson._type === "https://in-toto.io/Statement/v0.1" ||
+            bomJson._type === "https://in-toto.io/Statement/v1") &&
+          bomJson.predicateType === "https://cyclonedx.org/bom" &&
+          bomJson.predicate
+        ) {
+          bomJson = bomJson.predicate;
+        }
+
+        if (isCycloneDxBom(bomJson)) {
+          return bomJson;
+        }
+      }
+    }
+  } catch (e) {
+    console.log(
+      `Unable to pull the SBOM attachment for ${image} natively! ${e.message}`,
+    );
+  }
+  return undefined;
+}
+
+function getDigest(buffer) {
+  return `sha256:${createHash("sha256").update(buffer).digest("hex")}`;
+}
+
+async function pushBlob(registry, repository, buffer, token) {
+  const scheme = registry.startsWith("localhost") ? "http" : "https";
+  const digest = getDigest(buffer);
+  const headers = {};
+  if (token) {
+    headers.Authorization = token.startsWith("Basic")
+      ? token
+      : `Bearer ${token}`;
+  }
+
+  // 1. Initiate upload
+  const initUrl = `${scheme}://${registry}/v2/${repository}/blobs/uploads/`;
+  const initRes = await cdxgenAgent.post(initUrl, {
+    headers,
+    throwHttpErrors: false,
+  });
+  if (initRes.statusCode === 201 || initRes.statusCode === 202) {
+    let location = initRes.headers.location;
+    if (!location.startsWith("http")) {
+      location = `${scheme}://${registry}${location.startsWith("/") ? "" : "/"}${location}`;
+    }
+    const uploadUrl = new URL(location);
+    uploadUrl.searchParams.set("digest", digest);
+
+    // 2. Upload blob
+    const putHeaders = {
+      ...headers,
+      "Content-Length": buffer.length.toString(),
+      "Content-Type": "application/octet-stream",
+    };
+    const putRes = await cdxgenAgent.put(uploadUrl.toString(), {
+      headers: putHeaders,
+      body: buffer,
+      throwHttpErrors: false,
+    });
+    if (putRes.statusCode === 201 || putRes.statusCode === 202) {
+      return { digest, size: buffer.length };
+    }
+    throw new Error(
+      `Failed to upload blob: ${putRes.statusCode} ${putRes.body}`,
+    );
+  }
+  if (initRes.statusCode === 401) {
+    throw new Error(
+      `Unauthorized to initiate blob upload: ${initRes.statusCode}`,
+    );
+  }
+  throw new Error(
+    `Failed to initiate blob upload: ${initRes.statusCode} ${initRes.body}`,
+  );
+}
+
+async function pushManifest(registry, repository, manifestObj, token) {
+  const scheme = registry.startsWith("localhost") ? "http" : "https";
+  const buffer = Buffer.from(JSON.stringify(manifestObj));
+  const digest = getDigest(buffer);
+  const url = `${scheme}://${registry}/v2/${repository}/manifests/${digest}`;
+  const headers = {
+    "Content-Type":
+      manifestObj.mediaType || "application/vnd.oci.image.manifest.v1+json",
+  };
+  if (token) {
+    headers.Authorization = token.startsWith("Basic")
+      ? token
+      : `Bearer ${token}`;
+  }
+  const res = await cdxgenAgent.put(url, {
+    headers,
+    body: buffer,
+    throwHttpErrors: false,
+  });
+  if (res.statusCode === 201 || res.statusCode === 202) {
+    return digest;
+  }
+  throw new Error(`Failed to push manifest: ${res.statusCode} ${res.body}`);
+}
+
+export async function attachBomNative(image, bomJson) {
+  const { registry, repository, reference } = parseImageRef(image);
+  const token = await getOciToken(registry, repository, "pull,push");
+
+  // 1. Fetch target manifest
+  const targetManifest = await fetchManifest(
+    registry,
+    repository,
+    reference,
+    token,
+  );
+  if (!targetManifest?.digest) {
+    throw new Error(`Target image ${image} not found or no access.`);
+  }
+
+  // 2. Push SBOM blob
+  const bomBuffer = Buffer.from(JSON.stringify(bomJson));
+  const blobInfo = await pushBlob(registry, repository, bomBuffer, token);
+
+  // Push the empty config blob ({}) required by the OCI 1.1 artifact manifest
+  const emptyConfigBuffer = Buffer.from("{}");
+  await pushBlob(registry, repository, emptyConfigBuffer, token);
+
+  // 3. Push OCI 1.1 Manifest
+  const manifestObj = {
+    schemaVersion: 2,
+    mediaType: "application/vnd.oci.image.manifest.v1+json",
+    artifactType: "application/vnd.cyclonedx+json",
+    config: {
+      mediaType: "application/vnd.oci.empty.v1+json",
+      digest:
+        "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+      size: 2,
+    },
+    layers: [
+      {
+        mediaType: "application/vnd.cyclonedx+json",
+        digest: blobInfo.digest,
+        size: blobInfo.size,
+      },
+    ],
+    subject: {
+      mediaType:
+        targetManifest.mediaType ||
+        "application/vnd.oci.image.manifest.v1+json",
+      digest: targetManifest.digest,
+      size: targetManifest.manifest
+        ? Buffer.from(JSON.stringify(targetManifest.manifest)).length
+        : 0,
+    },
+    annotations: {
+      "org.opencontainers.image.created": new Date().toISOString(),
+    },
+  };
+
+  let manifestDigest = await pushManifest(
+    registry,
+    repository,
+    manifestObj,
+    token,
+  );
+
+  // Probe if referrers API is supported by the registry
+  const probeUrl = `${registry.startsWith("localhost") ? "http" : "https"}://${registry}/v2/${repository}/referrers/${targetManifest.digest}`;
+  const probeHeaders = token
+    ? { Authorization: token.startsWith("Basic") ? token : `Bearer ${token}` }
+    : {};
+  const probeRes = await cdxgenAgent.get(probeUrl, {
+    headers: probeHeaders,
+    throwHttpErrors: false,
+  });
+
+  if (probeRes.statusCode === 404 || probeRes.statusCode === 400) {
+    // Registry does not support referrers API natively. Create the fallback tag.
+    const fallbackTag = targetManifest.digest.replace(":", "-");
+
+    // Check if the fallback tag already exists (an Image Index)
+    const fallbackUrl = `${registry.startsWith("localhost") ? "http" : "https"}://${registry}/v2/${repository}/manifests/${fallbackTag}`;
+    const getRes = await cdxgenAgent.get(fallbackUrl, {
+      headers: {
+        ...probeHeaders,
+        Accept: "application/vnd.oci.image.index.v1+json",
+      },
+      responseType: "json",
+      throwHttpErrors: false,
+    });
+
+    let indexObj;
+    if (getRes.statusCode === 200 && getRes.body && getRes.body.manifests) {
+      indexObj = getRes.body;
+      indexObj.manifests.push({
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        digest: manifestDigest,
+        size: Buffer.from(JSON.stringify(manifestObj)).length,
+        artifactType: "application/vnd.cyclonedx+json",
+      });
+    } else {
+      indexObj = {
+        schemaVersion: 2,
+        mediaType: "application/vnd.oci.image.index.v1+json",
+        manifests: [
+          {
+            mediaType: "application/vnd.oci.image.manifest.v1+json",
+            digest: manifestDigest,
+            size: Buffer.from(JSON.stringify(manifestObj)).length,
+            artifactType: "application/vnd.cyclonedx+json",
+          },
+        ],
+      };
+    }
+
+    const indexBuffer = Buffer.from(JSON.stringify(indexObj));
+    const putHeaders = {
+      ...probeHeaders,
+      "Content-Type": "application/vnd.oci.image.index.v1+json",
+    };
+    await cdxgenAgent.put(fallbackUrl, {
+      headers: putHeaders,
+      body: indexBuffer,
+      throwHttpErrors: false,
+    });
+    manifestDigest = getDigest(indexBuffer);
+  }
+
+  console.log(`Attached SBOM natively to ${image} via ${manifestDigest}`);
+  return manifestDigest;
 }

--- a/lib/managers/oci.poku.js
+++ b/lib/managers/oci.poku.js
@@ -1,26 +1,18 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
-
 import esmock from "esmock";
 import { assert, describe, it } from "poku";
 import sinon from "sinon";
 
-async function loadOciModule({ getAllFiles, getTmpDir, safeSpawnSync }) {
+async function loadOciModule({ cdxgenAgentMock }) {
   return esmock("./oci.js", {
     "../helpers/utils.js": {
-      getAllFiles,
-      getTmpDir,
-      isWin: false,
-      safeSpawnSync,
+      cdxgenAgent: cdxgenAgentMock,
+      safeExistsSync: () => false,
     },
   });
 }
 
-describe("getBomWithOras()", () => {
+describe("getBomWithOras() native implementation", () => {
   it("pulls the newest digest-only SBOM referrer", async () => {
-    const tmpDir = mkdtempSync(path.join(os.tmpdir(), "cdxgen-oci-poku-"));
-    const bomFile = path.join(tmpDir, "sbom-oci-image.cdx.json");
     const bomJson = {
       bomFormat: "CycloneDX",
       specVersion: "1.6",
@@ -29,104 +21,103 @@ describe("getBomWithOras()", () => {
         value: "signed",
       },
     };
-    const safeSpawnSync = sinon.stub();
-    const getAllFiles = sinon.stub();
-    try {
-      writeFileSync(bomFile, JSON.stringify(bomJson), "utf8");
-      safeSpawnSync
-        .onCall(0)
-        .returns({
-          status: 0,
-          stdout: JSON.stringify({
-            referrers: [
-              {
-                digest: "sha256:older",
-                annotations: {
-                  "org.opencontainers.image.created": "2026-04-29T01:26:38Z",
-                },
-              },
-              {
-                digest: "sha256:newer",
-                annotations: {
-                  "org.opencontainers.image.created": "2026-04-29T02:00:20Z",
-                },
-              },
-            ],
-          }),
-        })
-        .onCall(1)
-        .returns({
-          status: 0,
-          stdout: "",
-        });
-      getAllFiles.withArgs(tmpDir, "**/*.{bom,cdx}.json").returns([bomFile]);
-      const { getBomWithOras } = await loadOciModule({
-        getAllFiles,
-        getTmpDir: sinon.stub().returns(tmpDir),
-        safeSpawnSync,
-      });
-      const result = getBomWithOras("ghcr.io/cdxgen/alpine-python313:master");
-      assert.deepStrictEqual(result, bomJson);
-      sinon.assert.calledWith(
-        safeSpawnSync,
-        "oras",
-        ["pull", "ghcr.io/cdxgen/alpine-python313@sha256:newer", "-o", tmpDir],
-        { shell: false },
-      );
-    } finally {
-      rmSync(tmpDir, { force: true, recursive: true });
-    }
-  });
 
-  it("falls back to bom.json when oras pulls a plain BOM filename", async () => {
-    const tmpDir = mkdtempSync(path.join(os.tmpdir(), "cdxgen-oci-poku-"));
-    const bomFile = path.join(tmpDir, "bom.json");
-    const bomJson = {
-      bomFormat: "CycloneDX",
-      specVersion: "1.6",
-      signature: {
-        algorithm: "RS512",
-        value: "signed",
-      },
+    const cdxgenAgentMock = {
+      get: sinon.stub(),
     };
-    const safeSpawnSync = sinon.stub();
-    const getAllFiles = sinon.stub();
-    try {
-      writeFileSync(bomFile, JSON.stringify(bomJson), "utf8");
-      safeSpawnSync
-        .onCall(0)
-        .returns({
-          status: 0,
-          stdout: JSON.stringify({
-            manifests: [
-              {
-                reference: "ghcr.io/cdxgen/demo@sha256:latest",
-              },
-            ],
-          }),
-        })
-        .onCall(1)
-        .returns({
-          status: 0,
-          stdout: "",
-        });
-      getAllFiles.withArgs(tmpDir, "**/*.{bom,cdx}.json").returns([]);
-      getAllFiles.withArgs(tmpDir, "**/bom.json").returns([bomFile]);
-      const { getBomWithOras } = await loadOciModule({
-        getAllFiles,
-        getTmpDir: sinon.stub().returns(tmpDir),
-        safeSpawnSync,
-      });
-      const result = getBomWithOras("ghcr.io/cdxgen/demo:master");
-      assert.deepStrictEqual(result, bomJson);
-      sinon.assert.calledWith(
-        safeSpawnSync,
-        "oras",
-        ["pull", "ghcr.io/cdxgen/demo@sha256:latest", "-o", tmpDir],
-        { shell: false },
-      );
-    } finally {
-      rmSync(tmpDir, { force: true, recursive: true });
-    }
+
+    // Mock get docker creds - implicitly false via safeExistsSync mock
+
+    // Mock /v2/ auth check
+    cdxgenAgentMock.get.onCall(0).resolves({
+      statusCode: 401,
+      headers: {},
+    });
+
+    // Mock fetch target manifest
+    cdxgenAgentMock.get.onCall(1).resolves({
+      statusCode: 200,
+      headers: {
+        "docker-content-digest": "sha256:targetdigest",
+        "content-type": "application/vnd.docker.distribution.manifest.v2+json",
+      },
+      body: { layers: [] },
+    });
+
+    // Mock discover referrers
+    cdxgenAgentMock.get.onCall(2).resolves({
+      statusCode: 200,
+      headers: {},
+      body: {
+        manifests: [
+          {
+            digest: "sha256:older",
+            annotations: {
+              "org.opencontainers.image.created": "2026-04-29T01:26:38Z",
+            },
+          },
+          {
+            digest: "sha256:newer",
+            annotations: {
+              "org.opencontainers.image.created": "2026-04-29T02:00:20Z",
+            },
+          },
+        ],
+      },
+    });
+
+    // Mock fetch referrer manifest
+    cdxgenAgentMock.get.onCall(3).resolves({
+      statusCode: 200,
+      headers: {
+        "docker-content-digest": "sha256:newer",
+        "content-type": "application/vnd.oci.image.manifest.v1+json",
+      },
+      body: {
+        layers: [{ digest: "sha256:blobdigest" }],
+      },
+    });
+
+    // Mock pull blob
+    cdxgenAgentMock.get.onCall(4).resolves({
+      statusCode: 200,
+      headers: {},
+      body: Buffer.from(JSON.stringify(bomJson)),
+    });
+
+    const { getBomWithOras } = await loadOciModule({
+      cdxgenAgentMock,
+    });
+
+    const result = await getBomWithOras(
+      "ghcr.io/cdxgen/alpine-python313:master",
+    );
+    assert.deepStrictEqual(result, bomJson);
+
+    // Validate auth check
+    assert.strictEqual(
+      cdxgenAgentMock.get.getCall(0).args[0],
+      "https://ghcr.io/v2/",
+    );
+    // Validate target manifest fetch
+    assert.strictEqual(
+      cdxgenAgentMock.get.getCall(1).args[0],
+      "https://ghcr.io/v2/cdxgen/alpine-python313/manifests/master",
+    );
+    // Validate referrers fetch
+    assert.strictEqual(
+      cdxgenAgentMock.get.getCall(2).args[0],
+      "https://ghcr.io/v2/cdxgen/alpine-python313/referrers/sha256:targetdigest?artifactType=application/vnd.cyclonedx+json",
+    );
+    // Validate referrer manifest fetch
+    assert.strictEqual(
+      cdxgenAgentMock.get.getCall(3).args[0],
+      "https://ghcr.io/v2/cdxgen/alpine-python313/manifests/sha256:newer",
+    );
+    // Validate blob pull
+    assert.strictEqual(
+      cdxgenAgentMock.get.getCall(4).args[0],
+      "https://ghcr.io/v2/cdxgen/alpine-python313/blobs/sha256:blobdigest",
+    );
   });
 });

--- a/lib/stages/postgen/auditBom.poku.js
+++ b/lib/stages/postgen/auditBom.poku.js
@@ -3620,6 +3620,75 @@ describe("evaluateRule", () => {
     assert.strictEqual(findings[0].severity, "medium");
   });
 
+  it("should detect container dependency using mutable latest tag (CTR-008)", async () => {
+    const rules = await loadRules(RULES_DIR);
+    const rule = rules.find((r) => r.id === "CTR-008");
+    assert.ok(rule, "CTR-008 rule should exist");
+
+    const bom = makeBom([
+      {
+        type: "container",
+        name: "ubuntu",
+        version: "latest",
+        purl: "pkg:oci/ubuntu@latest",
+        "bom-ref": "pkg:oci/ubuntu@latest",
+      },
+    ]);
+
+    const findings = await evaluateRule(rule, bom);
+    assert.ok(
+      findings.length > 0,
+      "Should detect container dependency using latest tag",
+    );
+    assert.strictEqual(findings[0].severity, "medium");
+  });
+
+  it("should detect container dependency lacking attached SBOM (CTR-009)", async () => {
+    const rules = await loadRules(RULES_DIR);
+    const rule = rules.find((r) => r.id === "CTR-009");
+    assert.ok(rule, "CTR-009 rule should exist");
+
+    const bom = makeBom([
+      {
+        type: "container",
+        name: "dummy-nonexistent-image",
+        version: "1.0.0",
+        purl: "pkg:oci/dummy-nonexistent-image@1.0.0",
+        "bom-ref": "pkg:oci/dummy-nonexistent-image@1.0.0",
+      },
+    ]);
+
+    const findings = await evaluateRule(rule, bom);
+    assert.ok(
+      findings.length > 0,
+      "Should detect container dependency lacking attached SBOM",
+    );
+    assert.strictEqual(findings[0].severity, "medium");
+  });
+
+  it("should detect container dependency lacking signed SBOM (CTR-010)", async () => {
+    const rules = await loadRules(RULES_DIR);
+    const rule = rules.find((r) => r.id === "CTR-010");
+    assert.ok(rule, "CTR-010 rule should exist");
+
+    const bom = makeBom([
+      {
+        type: "container",
+        name: "dummy-nonexistent-image-unsigned",
+        version: "1.0.0",
+        purl: "pkg:oci/dummy-nonexistent-image-unsigned@1.0.0",
+        "bom-ref": "pkg:oci/dummy-nonexistent-image-unsigned@1.0.0",
+      },
+    ]);
+
+    const findings = await evaluateRule(rule, bom);
+    assert.strictEqual(
+      findings.length,
+      0,
+      "Should not trigger signed SBOM rule if hasSbom is false",
+    );
+  });
+
   it("should detect privileged listener exposed on all interfaces (OBOM-LNX-006)", async () => {
     const rules = await loadRules(RULES_DIR);
     const rule = rules.find((r) => r.id === "OBOM-LNX-006");

--- a/lib/stages/postgen/ruleEngine.js
+++ b/lib/stages/postgen/ruleEngine.js
@@ -5,6 +5,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
+import { PackageURL } from "packageurl-js";
 import { parse as loadYaml } from "yaml";
 
 import { DEBUG_MODE, safeExistsSync } from "../../helpers/utils.js";
@@ -188,10 +189,93 @@ async function safeEvaluate(expression, context, timeoutMs = 5000) {
   });
 }
 
+function getImageRef(val) {
+  if (typeof val === "string") {
+    return val;
+  }
+  if (val && typeof val === "object") {
+    // Try extract from purl first
+    if (val.purl && typeof val.purl === "string") {
+      try {
+        const purlObj = PackageURL.fromString(val.purl);
+        if (purlObj.type === "oci") {
+          let repo = purlObj.name;
+          const repoUrl = purlObj.qualifiers?.repository_url;
+          if (repoUrl) {
+            repo = repoUrl.replace(/^https?:\/\//, "");
+          }
+          if (purlObj.version) {
+            if (purlObj.version.startsWith("sha256:")) {
+              return `${repo}@${purlObj.version}`;
+            }
+            return `${repo}:${purlObj.version}`;
+          }
+          const tag = purlObj.qualifiers?.tag;
+          if (tag) {
+            return `${repo}:${tag}`;
+          }
+          return repo;
+        }
+      } catch {
+        // ignore purl parse errors
+      }
+    }
+    // Fallback to name/version
+    if (val.name) {
+      if (val.name.includes(":") || val.name.includes("@")) {
+        return val.name;
+      }
+      if (val.version) {
+        return `${val.name}:${val.version}`;
+      }
+      return val.name;
+    }
+  }
+  return null;
+}
+
 /**
  * Register custom JSONata functions for CycloneDX property access
  */
 function registerCdxHelpers(expression) {
+  expression.registerFunction("hasSbom", async (val) => {
+    const image = getImageRef(val);
+    if (!image) return false;
+    try {
+      const { getBomWithOras } = await import("../../managers/oci.js");
+      const bom = await getBomWithOras(image);
+      return bom !== undefined;
+    } catch {
+      return false;
+    }
+  });
+
+  expression.registerFunction("hasSignedSbom", async (val) => {
+    const image = getImageRef(val);
+    if (!image) return false;
+    try {
+      const { getBomWithOras } = await import("../../managers/oci.js");
+      const bom = await getBomWithOras(image);
+      if (!bom) return false;
+      if (bom.signature) return true;
+      if (
+        Array.isArray(bom.components) &&
+        bom.components.some((c) => c.signature)
+      )
+        return true;
+      if (Array.isArray(bom.services) && bom.services.some((s) => s.signature))
+        return true;
+      if (
+        Array.isArray(bom.annotations) &&
+        bom.annotations.some((a) => a.signature)
+      )
+        return true;
+      return false;
+    } catch {
+      return false;
+    }
+  });
+
   expression.registerFunction("prop", (obj, propName) =>
     extractProperty(obj, propName),
   );


### PR DESCRIPTION
oci.js includes a lightweight implementation to pull and push attachments. oras cli is no longer required since sign.js can also attach.