### PR TITLE
fix(os): canonical distro namespace and codename-only distro_name

### DIFF
--- a/lib/managers/binary.js
+++ b/lib/managers/binary.js
@@ -47,6 +47,13 @@ import { getDirs } from "./containerutils.js";
 
 const isWin = _platform() === "win32";
 const OS_PURL_TYPES = ["deb", "apk", "rpm", "alpm", "qpkg"];
+// Canonical distro vendor namespace. Trivy emits pkg:rpm/alma/... but the
+// vulnerability feeds (AppThreat vuln-list / dep-scan) key AlmaLinux under
+// "almalinux"; align so the purls match. Rocky is emitted as "rocky" already.
+const OS_DISTRO_NAMESPACE_ALIAS = {
+  alma: "almalinux",
+  "rocky-linux": "rocky",
+};
 const pluginRuntime = setPluginsPathEnv(resolveCdxgenPlugins());
 const platform = pluginRuntime.platform;
 const CDXGEN_PLUGINS_DIR = pluginRuntime.pluginsDir;
@@ -643,15 +650,28 @@ export async function getOSPackages(src, imageConfig, options = {}) {
       if (DEBUG_MODE) {
         console.log(osReleaseData);
       }
-      let distro_codename =
-        osReleaseData["VERSION_CODENAME"] ||
-        osReleaseData["CENTOS_MANTISBT_PROJECT"] ||
-        osReleaseData["REDHAT_BUGZILLA_PRODUCT"] ||
-        osReleaseData["REDHAT_SUPPORT_PRODUCT"] ||
-        "";
-      distro_codename = distro_codename.toLowerCase();
-      if (distro_codename.includes(" ") && OS_DISTRO_ALIAS[distro_codename]) {
-        distro_codename = OS_DISTRO_ALIAS[distro_codename];
+      // distro_name must be a real release codename/token (bookworm, jammy,
+      // rhel-9, alpine-3.19), never a distro *display name*. VERSION_CODENAME is
+      // authoritative when present; otherwise the RHEL/CentOS product-name
+      // fallbacks are only accepted when they resolve through OS_DISTRO_ALIAS
+      // (e.g. "red hat enterprise linux 9" -> "rhel-9"). Display names such as
+      // "Rocky Linux" or "AlmaLinux" have no alias entry and are dropped so we
+      // never emit a bogus distro_name qualifier (RPM distros track packages
+      // flat, without a release segment, so folding a display name breaks
+      // downstream vuln-db matching).
+      let distro_codename = (
+        osReleaseData["VERSION_CODENAME"] || ""
+      ).toLowerCase();
+      if (!distro_codename) {
+        const distro_display_name = (
+          osReleaseData["CENTOS_MANTISBT_PROJECT"] ||
+          osReleaseData["REDHAT_BUGZILLA_PRODUCT"] ||
+          osReleaseData["REDHAT_SUPPORT_PRODUCT"] ||
+          ""
+        ).toLowerCase();
+        if (distro_display_name && OS_DISTRO_ALIAS[distro_display_name]) {
+          distro_codename = OS_DISTRO_ALIAS[distro_display_name];
+        }
       }
       let distro_id = osReleaseData["ID"] || "";
       const distro_id_like = osReleaseData["ID_LIKE"] || "";
@@ -728,10 +748,42 @@ export async function getOSPackages(src, imageConfig, options = {}) {
             } catch (_err) {
               // continue regardless of error
             }
+            // Canonicalise the distro vendor namespace for every OS component,
+            // regardless of whether trivy expressed the vendor via the purl
+            // namespace or the component group (it is inconsistent between
+            // packages). e.g. pkg:rpm/alma/... -> pkg:rpm/almalinux/... so the
+            // purls match the vulnerability feeds. Also aligns the ``distro``
+            // qualifier vendor prefix (alma-9.8 -> almalinux-9.8).
+            if (purlObj && OS_PURL_TYPES.includes(purlObj.type)) {
+              const os_ns = purlObj.namespace || group || "";
+              const os_ns_alias = OS_DISTRO_NAMESPACE_ALIAS[os_ns];
+              if (os_ns_alias) {
+                group = os_ns_alias;
+                comp.group = os_ns_alias;
+                purlObj.namespace = os_ns_alias;
+                const distroQual = purlObj.qualifiers?.distro;
+                if (distroQual?.startsWith(`${os_ns}-`)) {
+                  purlObj.qualifiers.distro = `${os_ns_alias}-${distroQual.slice(
+                    os_ns.length + 1,
+                  )}`;
+                }
+                comp.purl = new PackageURL(
+                  purlObj.type,
+                  os_ns_alias,
+                  name,
+                  purlObj.version,
+                  purlObj.qualifiers,
+                  purlObj.subpath,
+                ).toString();
+                comp["bom-ref"] = decodeURIComponent(comp.purl);
+              }
+            }
             if (group === "" && OS_PURL_TYPES.includes(purlObj["type"])) {
               try {
                 if (purlObj?.namespace && purlObj.namespace !== "") {
-                  group = purlObj.namespace;
+                  group =
+                    OS_DISTRO_NAMESPACE_ALIAS[purlObj.namespace] ||
+                    purlObj.namespace;
                   comp.group = group;
                   purlObj.namespace = group;
                 }


### PR DESCRIPTION
RPM OS purls did not match AppThreat vdb / dep-scan:
- AlmaLinux was emitted inconsistently as pkg:rpm/alma/... (some components) vs pkg:rpm/almalinux/... The vuln feeds key it under 'almalinux'. Canonicalise the distro vendor namespace for every OS component (alma -> almalinux; rocky-linux -> rocky), and align the 'distro' qualifier vendor prefix (alma-9.8 -> almalinux-9.8).
- distro_name carried the distro *display name* for RPM distros (e.g. 'rocky linux', 'almalinux') because the RHEL bugzilla/support product fallback was used verbatim. That is not a release codename, so consumers that fold distro_name into the package path produce a guaranteed miss. Only accept the product-name fallback when it resolves through OS_DISTRO_ALIAS (e.g. 'red hat enterprise linux 9' -> 'rhel-9'); otherwise leave distro_name unset. deb/apk codenames (bookworm, jammy, alpine-3.19) are unchanged.

Epoch handling is intentionally left as-is (epoch folded into version plus qualifier); the downstream vdb comparator handles epoch/no-epoch matching.