### PR TITLE
fix(sbt): memoize jar distribution lookups and discover projects via sbt to fix hang (#4291)

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -122,6 +122,7 @@ import {
   determineSbtVersion,
   discoverSbtProjects,
   parseSbtLock,
+  parseSbtProjects,
   parseSbtRootProject,
   parseSbtTree,
 } from "../helpers/sbtutils.js";
@@ -1718,6 +1719,65 @@ export function createBinaryBom(path, options) {
 }
 
 /**
+ * Discover the real sbt project ids for a build by invoking sbt's own
+ * `projects` command. This is more reliable than scraping the build files with
+ * a regex, since it uses sbt's project resolution and avoids false positives
+ * (commented-out code, examples, values that merely resemble project defs) that
+ * can lead to hangs when those bogus scopes are later passed to `dependencyTree`.
+ *
+ * Falls back to the regex-based {@link discoverSbtProjects} heuristic when the
+ * sbt invocation fails or yields nothing useful.
+ *
+ * @param {string} basePath Directory of the sbt build
+ * @param {string} sbtCmd sbt executable
+ * @param {Object} env Environment for the spawned process
+ * @returns {string[]} List of sbt project ids
+ */
+function discoverSbtProjectsFromCmd(basePath, sbtCmd, env) {
+  try {
+    const result = safeSpawnSync(
+      sbtCmd,
+      ["-batch", "-no-colors", '"projects"'],
+      {
+        cwd: basePath,
+        shell: true,
+        env,
+        encoding: "utf-8",
+      },
+    );
+    if (result.status === 0 && !result.error) {
+      const { projects, root } = parseSbtProjects(result.stdout || "");
+      // Exclude the aggregating root project - its own dependencyTree is
+      // usually a subset of the aggregated subprojects and re-resolving it
+      // only adds noise/time.
+      const subprojects = projects.filter((p) => p !== root);
+      if (subprojects.length > 0) {
+        if (DEBUG_MODE) {
+          console.log(
+            `Discovered sbt projects via sbt: ${subprojects.join(", ")}`,
+          );
+        }
+        return subprojects;
+      }
+      // Single-project builds (root only): resolve at the root scope.
+      if (projects.length > 0) {
+        return [];
+      }
+    } else if (DEBUG_MODE) {
+      console.log(
+        "sbt projects command did not succeed. Falling back to heuristic project discovery.",
+      );
+    }
+  } catch (err) {
+    if (DEBUG_MODE) {
+      console.log("Unable to run sbt projects command.", err);
+    }
+  }
+  // Fallback to the regex-based heuristic.
+  return discoverSbtProjects(basePath);
+}
+
+/**
  * Function to create bom string for Java projects
  *
  * @param {string} path to the project
@@ -2945,7 +3005,16 @@ export async function createJavaBom(path, options) {
           subDlFiles.push(dlFile);
         } else {
           // write to the existing plugins file
-          const subprojects = discoverSbtProjects(basePath);
+          // Discover the real sbt project ids by asking sbt itself, falling
+          // back to the regex-based heuristic if that fails. A per-subproject
+          // `dependencyTree` fan-out yields a far more complete tree than a
+          // single root resolution (which only captures the root project's own
+          // libraryDependencies). See https://github.com/cdxgen/cdxgen/issues/4291
+          const subprojects = discoverSbtProjectsFromCmd(
+            basePath,
+            SBT_CMD,
+            env,
+          );
           if (subprojects.length > 0 && useSlashSyntax) {
             sbtArgs = [
               `'set ThisBuild / asciiGraphWidth := 800'${sbtExtraArgs}`,
@@ -2970,6 +3039,10 @@ export async function createJavaBom(path, options) {
           }
           pluginFile = addPlugin(basePath, sbtPluginDefinition);
         }
+        // Run sbt in non-interactive batch mode so it never blocks waiting for
+        // input on stdin (which can otherwise appear as an indefinite hang) and
+        // does not emit ANSI colour codes into the dependency tree output.
+        sbtArgs = ["-batch", "-no-colors", ...sbtArgs];
         console.log(
           "Executing",
           SBT_CMD,

--- a/lib/helpers/sbtutils.js
+++ b/lib/helpers/sbtutils.js
@@ -343,9 +343,23 @@ export function findLocalJarPath(group, name, version) {
  * @param {string} version Package version
  * @returns {Promise<{ repoUrl: string, jarUrl: string, hashes?: Array }|null>} resolved URLs or null
  */
+// Memoization cache for resolveJarDistribution. The sbt dependency tree
+// repeats the same coordinates many times (thousands of lines resolving to a
+// few hundred unique packages), and each resolution performs recursive globs
+// over the Coursier cache plus jar hashing. Without this cache, parsing a
+// large tree performed the same expensive lookups over and over, which could
+// take many minutes and appear as a hang. See
+// https://github.com/cdxgen/cdxgen/issues/4291
+const _jarDistributionCache = new Map();
+
 export async function resolveJarDistribution(group, name, version) {
+  const cacheKey = `${group}:${name}:${version}`;
+  if (_jarDistributionCache.has(cacheKey)) {
+    return _jarDistributionCache.get(cacheKey);
+  }
   const repoUrl = findCoursierRegistryUrl(group, name, version);
   if (!repoUrl) {
+    _jarDistributionCache.set(cacheKey, null);
     return null;
   }
   const groupPath = group.replace(/\./g, "/");
@@ -368,6 +382,7 @@ export async function resolveJarDistribution(group, name, version) {
       // ignore
     }
   }
+  _jarDistributionCache.set(cacheKey, result);
   return result;
 }
 
@@ -717,6 +732,74 @@ export function discoverSbtProjects(projectPath) {
     }
   }
   return [...projects];
+}
+
+/**
+ * Parse the output of the sbt `projects` command to extract the real project
+ * identifiers as understood by sbt. This is more accurate than scraping the
+ * build files with a regex (see {@link discoverSbtProjects}), since it relies
+ * on sbt's own project resolution and therefore avoids false positives from
+ * commented-out code, examples or values that merely look like project
+ * definitions.
+ *
+ * A typical `sbt projects` output looks like:
+ *
+ * ```
+ * [info] In file:/path/to/build/
+ * [info] 	   * chen
+ * [info] 	     platform
+ * [info] 	     dataflowengineoss
+ * ```
+ *
+ * The project marked with `*` is the currently selected (usually the
+ * aggregating root) project.
+ *
+ * @param {string} stdout Raw stdout captured from `sbt projects`
+ * @returns {{projects: string[], root: string | undefined}} The discovered
+ *  project ids and the currently selected (root) project id, if any.
+ */
+export function parseSbtProjects(stdout) {
+  const projects = [];
+  let root;
+  if (!stdout) {
+    return { projects, root };
+  }
+  const lines = stdout.split(/\r?\n/);
+  // Matches lines such as `[info]    * name` or `[info]      name`.
+  // The optional `[info]` prefix is stripped first so we can tolerate
+  // different sbt log levels/formats.
+  const projectLineRegex = /^(\*)?\s*([a-zA-Z0-9_.-]+)\s*$/;
+  let inProjectsBlock = false;
+  for (const rawLine of lines) {
+    // Strip the leading `[info]`/`[warn]` log prefix, if any.
+    const line = rawLine.replace(/^\[[a-z]+\]\s?/i, "");
+    if (/^In\s+\S+/.test(line.trim())) {
+      inProjectsBlock = true;
+      continue;
+    }
+    if (!inProjectsBlock) {
+      continue;
+    }
+    const trimmed = line.trim();
+    if (!trimmed) {
+      // A blank line terminates the projects listing.
+      break;
+    }
+    const match = projectLineRegex.exec(trimmed);
+    if (!match) {
+      continue;
+    }
+    const isCurrent = Boolean(match[1]);
+    const projName = match[2];
+    if (!projName || projName === "info" || projName === "warn") {
+      continue;
+    }
+    projects.push(projName);
+    if (isCurrent) {
+      root = projName;
+    }
+  }
+  return { projects, root };
 }
 
 /**

--- a/lib/helpers/sbtutils.poku.js
+++ b/lib/helpers/sbtutils.poku.js
@@ -10,6 +10,7 @@ import {
   findCoursierRegistryUrl,
   findLocalJarPath,
   parseSbtLock,
+  parseSbtProjects,
   parseSbtTree,
   resolveJarDistribution,
 } from "./sbtutils.js";
@@ -35,6 +36,38 @@ it("parse scala sbt tree", async () => {
   );
   assert.ok(compilerVersionProp);
   assert.strictEqual(compilerVersionProp.value, "2.13");
+});
+
+it("parse sbt projects output", () => {
+  const output = `[info] welcome to sbt 1.11.7
+[info] loading project definition
+[info] In file:/app/
+[info] 	   * chen
+[info] 	     platform
+[info] 	     dataflowengineoss
+[info] 	     semanticcpg
+[info]
+[info] done`;
+  const { projects, root } = parseSbtProjects(output);
+  assert.strictEqual(root, "chen");
+  assert.deepStrictEqual(projects, [
+    "chen",
+    "platform",
+    "dataflowengineoss",
+    "semanticcpg",
+  ]);
+
+  // Single project build (root only)
+  const singleOutput = `[info] In file:/app/
+[info] 	   * atom`;
+  const single = parseSbtProjects(singleOutput);
+  assert.strictEqual(single.root, "atom");
+  assert.deepStrictEqual(single.projects, ["atom"]);
+
+  // Empty / unexpected output
+  const empty = parseSbtProjects("");
+  assert.deepStrictEqual(empty.projects, []);
+  assert.strictEqual(empty.root, undefined);
 });
 
 it("parse scala sbt lock", async () => {


### PR DESCRIPTION
Root cause (regression from PR #4186): parseSbtTree calls resolveJarDistribution on every tree line before deduplication. For atom that's 6,121 calls for only 118 unique packages, and each call does two recursive **/ globs over a Coursier cache of 33,294 entries plus 4-way jar hashing — ~12,000 full cache walks. sbt itself finishes in 7 seconds;